### PR TITLE
Generic hidden state for RecurrentPPO

### DIFF
--- a/stable_baselines3/common/pytree_dataclass.py
+++ b/stable_baselines3/common/pytree_dataclass.py
@@ -17,10 +17,9 @@ from typing import (
 import optree as ot
 import torch as th
 from optree import CustomTreeNode, PyTree
-from typing_extensions import dataclass_transform
-
 from stable_baselines3.common.type_aliases import TensorIndex
 from stable_baselines3.common.utils import zip_strict
+from typing_extensions import dataclass_transform
 
 __all__ = [
     "FrozenPyTreeDataclass",
@@ -105,10 +104,10 @@ class _PyTreeDataclassMeta(type(CustomTreeNode)):  # type: ignore[misc]
 
             frozen = issubclass(cls, FrozenPyTreeDataclass)
             if frozen:
-                if not (not issubclass(cls, MutablePyTreeDataclass) and issubclass(cls, FrozenPyTreeDataclass)):
+                if issubclass(cls, MutablePyTreeDataclass) or not issubclass(cls, FrozenPyTreeDataclass):
                     raise TypeError(f"Frozen dataclass {cls} should inherit from FrozenPyTreeDataclass")
             else:
-                if not (issubclass(cls, MutablePyTreeDataclass) and not issubclass(cls, FrozenPyTreeDataclass)):
+                if not issubclass(cls, MutablePyTreeDataclass) or issubclass(cls, FrozenPyTreeDataclass)):
                     raise TypeError(f"Mutable dataclass {cls} should inherit from MutablePyTreeDataclass")
 
             # Calling `dataclasses.dataclass` here, with slots, is what triggers the EARLY RETURN path above.

--- a/stable_baselines3/common/pytree_dataclass.py
+++ b/stable_baselines3/common/pytree_dataclass.py
@@ -17,9 +17,10 @@ from typing import (
 import optree as ot
 import torch as th
 from optree import CustomTreeNode, PyTree
+from typing_extensions import dataclass_transform
+
 from stable_baselines3.common.type_aliases import TensorIndex
 from stable_baselines3.common.utils import zip_strict
-from typing_extensions import dataclass_transform
 
 __all__ = [
     "FrozenPyTreeDataclass",
@@ -83,9 +84,8 @@ class _PyTreeDataclassMeta(type(CustomTreeNode)):  # type: ignore[misc]
                 # Otherwise we just mark the current class as what we're registering.
                 if not issubclass(cls, (FrozenPyTreeDataclass, MutablePyTreeDataclass)):
                     raise TypeError(f"Dataclass {cls} should inherit from FrozenPyTreeDataclass or MutablePyTreeDataclass")
-                mcs.currently_registering = cls
-        else:
-            mcs.currently_registering = cls
+
+        mcs.currently_registering = cls
 
         if name in _RESERVED_NAMES:
             if not (
@@ -107,7 +107,7 @@ class _PyTreeDataclassMeta(type(CustomTreeNode)):  # type: ignore[misc]
                 if issubclass(cls, MutablePyTreeDataclass) or not issubclass(cls, FrozenPyTreeDataclass):
                     raise TypeError(f"Frozen dataclass {cls} should inherit from FrozenPyTreeDataclass")
             else:
-                if not issubclass(cls, MutablePyTreeDataclass) or issubclass(cls, FrozenPyTreeDataclass)):
+                if not issubclass(cls, MutablePyTreeDataclass) or issubclass(cls, FrozenPyTreeDataclass):
                     raise TypeError(f"Mutable dataclass {cls} should inherit from MutablePyTreeDataclass")
 
             # Calling `dataclasses.dataclass` here, with slots, is what triggers the EARLY RETURN path above.


### PR DESCRIPTION
(This PR is after #7 and #8 , which I factored out to make review easier.)

Add the remaining parts for generic-state recurrent PPO.

- The policy in `common/recurrent/policies.py` is still based on LSTMs, but now uses the `recurrent_initial_state(...)` interface to indicate what its hidden state is.
- `RecurrentPPO` is fully generic over hidden state types.
- Fixed all the type errors
  - Also re-enabled mypy for the whole codebase