### PR TITLE
Introduce recurrent policies backed by RecurrentFeatureExtractors

### DIFF
--- a/stable_baselines3/common/recurrent/policies.py
+++ b/stable_baselines3/common/recurrent/policies.py
@@ -623,7 +623,7 @@ class RecurrentMultiInputActorCriticPolicy(RecurrentActorCriticPolicy):
         )
 
 
-class RecurrentFeaturesExtractorActorCriticPolicy(ActorCriticPolicy, Generic[ExtractorInput, RecurrentState]):
+class RecurrentFeaturesExtractorActorCriticPolicy(BaseRecurrentActorCriticPolicy, Generic[ExtractorInput, RecurrentState]):
     features_extractor: RecurrentFeaturesExtractor[ExtractorInput, RecurrentState]
 
     def __init__(

--- a/stable_baselines3/common/recurrent/torch_layers.py
+++ b/stable_baselines3/common/recurrent/torch_layers.py
@@ -1,0 +1,158 @@
+import abc
+from typing import Generic, Optional, Tuple, TypeVar
+
+import gymnasium as gym
+import torch as th
+
+from stable_baselines3.common.pytree_dataclass import TensorTree, tree_flatten, tree_map
+from stable_baselines3.common.torch_layers import (
+    BaseFeaturesExtractor,
+    CombinedExtractor,
+    FlattenExtractor,
+    NatureCNN,
+)
+from stable_baselines3.common.type_aliases import TorchGymObs
+
+RecurrentState = TypeVar("RecurrentState", bound=TensorTree)
+
+RecurrentSubState = TypeVar("RecurrentSubState", bound=TensorTree)
+
+
+class RecurrentFeaturesExtractor(BaseFeaturesExtractor, abc.ABC, Generic[RecurrentState]):
+    @abc.abstractmethod
+    def recurrent_initial_state(
+        self, n_envs: Optional[int] = None, *, device: Optional[th.device | str] = None
+    ) -> RecurrentState:
+        ...
+
+    @abc.abstractmethod
+    def forward(
+        self, observations: TorchGymObs, state: RecurrentState, episode_starts: th.Tensor
+    ) -> Tuple[th.Tensor, RecurrentState]:
+        ...
+
+    @staticmethod
+    def _process_sequence(
+        rnn: th.nn.RNNBase, inputs: th.Tensor, init_state: RecurrentSubState, episode_starts: th.Tensor
+    ) -> Tuple[th.Tensor, RecurrentSubState]:
+        (state_example, *_), _ = tree_flatten(init_state, is_leaf=None)
+        n_layers, batch_sz, *_ = state_example.shape
+
+        # Batch to sequence
+        # (padded batch size, features_dim) -> (n_seq, max length, features_dim) -> (max length, n_seq, features_dim)
+        seq_len = inputs.shape[0] // batch_sz
+        seq_inputs = inputs.view((batch_sz, seq_len, *inputs.shape[1:])).swapaxes(0, 1)
+        episode_starts = episode_starts.view((batch_sz, seq_len)).swapaxes(0, 1)
+
+        if th.any(episode_starts[1:]):
+            raise NotImplementedError("Resetting state in the middle of a sequence is not supported")
+
+        first_state_is_not_reset = (~episode_starts[0]).contiguous()
+        # Shape here is (n_layers, batch_sz)
+        init_state = tree_map(lambda x: x * first_state_is_not_reset.view((1, batch_sz, *(1,) * (x.ndim - 2))), init_state)
+        rnn_output, end_state = rnn(seq_inputs, init_state)
+
+        # (seq_len, batch_size, ...) -> (batch_size, seq_len, ...) -> (batch_size * seq_len, ...)
+        rnn_output = rnn_output.transpose(0, 1).reshape((batch_sz * seq_len, *rnn_output.shape[2:]))
+        return rnn_output, end_state
+
+
+GRURecurrentState = th.Tensor
+
+
+class GRUWrappedFeaturesExtractor(RecurrentFeaturesExtractor[GRURecurrentState]):
+    def __init__(
+        self,
+        observation_space: gym.Space,
+        base_extractor: BaseFeaturesExtractor,
+        features_dim: Optional[int] = None,
+        num_layers: int = 1,
+        bias: bool = True,
+        dropout: float = 0.0,
+    ):
+        if features_dim is None:
+            # Ensure features_dim is at least 64 by default so it optimizes fine
+            features_dim = max(base_extractor.features_dim, 64)
+
+        assert observation_space == base_extractor._observation_space
+
+        super().__init__(observation_space, features_dim)
+        self.base_extractor = base_extractor
+
+        self.rnn = th.nn.GRU(
+            input_size=base_extractor.features_dim,
+            hidden_size=features_dim,
+            num_layers=num_layers,
+            bias=bias,
+            batch_first=False,
+            dropout=dropout,
+            bidirectional=False,
+        )
+
+    def recurrent_initial_state(
+        self, n_envs: Optional[int] = None, *, device: Optional[th.device | str] = None
+    ) -> GRURecurrentState:
+        shape: Tuple[int, ...]
+        if n_envs is None:
+            shape = (self.rnn.num_layers, self.rnn.hidden_size)
+        else:
+            shape = (self.rnn.num_layers, n_envs, self.rnn.hidden_size)
+        return th.zeros(shape, device=device)
+
+    def forward(
+        self, observations: TorchGymObs, state: GRURecurrentState, episode_starts: th.Tensor
+    ) -> Tuple[th.Tensor, GRURecurrentState]:
+        features: th.Tensor = self.base_extractor(observations)
+        return self._process_sequence(self.rnn, features, state, episode_starts)
+
+    @property
+    def features_dim(self) -> int:
+        return self.rnn.hidden_size
+
+
+class GRUFlattenExtractor(GRUWrappedFeaturesExtractor):
+    def __init__(
+        self,
+        observation_space: gym.Space,
+        features_dim: int = 64,
+        num_layers: int = 1,
+        bias: bool = True,
+        dropout: float = 0.0,
+    ) -> None:
+        base_extractor = FlattenExtractor(observation_space)
+        super().__init__(
+            observation_space, base_extractor, features_dim=features_dim, num_layers=num_layers, bias=bias, dropout=dropout
+        )
+
+
+class GRUNatureCNNExtractor(GRUWrappedFeaturesExtractor):
+    def __init__(
+        self,
+        observation_space: gym.Space,
+        features_dim: int = 512,
+        normalized_image: bool = False,
+        num_layers: int = 1,
+        bias: bool = True,
+        dropout: float = 0.0,
+    ) -> None:
+        base_extractor = NatureCNN(observation_space, features_dim=features_dim, normalized_image=normalized_image)
+        super().__init__(
+            observation_space, base_extractor, features_dim=features_dim, num_layers=num_layers, bias=bias, dropout=dropout
+        )
+
+
+class GRUCombinedExtractor(GRUWrappedFeaturesExtractor):
+    def __init__(
+        self,
+        observation_space: gym.spaces.Dict,
+        features_dim: int = 64,
+        cnn_output_dim: int = 256,
+        normalized_image: bool = False,
+        num_layers: int = 1,
+        bias: bool = True,
+        dropout: float = 0.0,
+    ) -> None:
+        base_extractor = CombinedExtractor(observation_space, cnn_output_dim=cnn_output_dim, normalized_image=normalized_image)
+        super().__init__(
+            observation_space, base_extractor, features_dim=features_dim, num_layers=num_layers, bias=bias, dropout=dropout
+        )

--- a/stable_baselines3/common/recurrent/type_aliases.py
+++ b/stable_baselines3/common/recurrent/type_aliases.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple, TypeVar
+from typing import Generic, Optional, Tuple, TypeVar
 
 import torch as th
 
@@ -13,12 +13,16 @@ def non_null(v: Optional[T]) -> T:
     return v
 
 
-LSTMStates = Tuple[th.Tensor, th.Tensor]
+TensorTreeT = TypeVar("TensorTreeT", bound=TensorTree)
 
 
-class RNNStates(FrozenPyTreeDataclass[th.Tensor]):
-    pi: LSTMStates
-    vf: LSTMStates
+LSTMRecurrentState = Tuple[th.Tensor, th.Tensor]
+GRURecurrentState = th.Tensor
+
+
+class ActorCriticStates(FrozenPyTreeDataclass[th.Tensor], Generic[TensorTreeT]):
+    pi: TensorTreeT
+    vf: TensorTreeT
 
 
 class RecurrentRolloutBufferData(FrozenPyTreeDataclass[th.Tensor]):

--- a/stable_baselines3/ppo_recurrent/ppo_recurrent.py
+++ b/stable_baselines3/ppo_recurrent/ppo_recurrent.py
@@ -14,8 +14,8 @@ from stable_baselines3.common.pytree_dataclass import tree_map
 from stable_baselines3.common.recurrent.buffers import RecurrentRolloutBuffer
 from stable_baselines3.common.recurrent.policies import RecurrentActorCriticPolicy
 from stable_baselines3.common.recurrent.type_aliases import (
+    ActorCriticStates,
     RecurrentRolloutBufferData,
-    RNNStates,
     non_null,
 )
 from stable_baselines3.common.type_aliases import GymEnv, MaybeCallback, Schedule
@@ -177,7 +177,7 @@ class RecurrentPPO(OnPolicyAlgorithm):
         self.clip_range_vf: Schedule = clip_range_vf  # type: ignore
         self.normalize_advantage = normalize_advantage
         self.target_kl = target_kl
-        self._last_lstm_states: Optional[RNNStates] = None
+        self._last_lstm_states: Optional[ActorCriticStates] = None
 
         if _init_setup_model:
             self._setup_model()

--- a/stable_baselines3/ppo_recurrent/ppo_recurrent.py
+++ b/stable_baselines3/ppo_recurrent/ppo_recurrent.py
@@ -12,7 +12,10 @@ from stable_baselines3.common.on_policy_algorithm import OnPolicyAlgorithm
 from stable_baselines3.common.policies import BasePolicy
 from stable_baselines3.common.pytree_dataclass import tree_map
 from stable_baselines3.common.recurrent.buffers import RecurrentRolloutBuffer
-from stable_baselines3.common.recurrent.policies import RecurrentActorCriticPolicy
+from stable_baselines3.common.recurrent.policies import (
+    BaseRecurrentActorCriticPolicy,
+    RecurrentActorCriticPolicy,
+)
 from stable_baselines3.common.recurrent.type_aliases import (
     ActorCriticStates,
     RecurrentRolloutBufferData,
@@ -95,7 +98,7 @@ class RecurrentPPO(OnPolicyAlgorithm):
 
     def __init__(
         self,
-        policy: Union[str, Type[RecurrentActorCriticPolicy]],
+        policy: Union[str, Type[BaseRecurrentActorCriticPolicy]],
         env: Union[GymEnv, str],
         learning_rate: Union[float, Schedule] = 3e-4,
         n_steps: int = 128,


### PR DESCRIPTION
This is an easier way to create many kinds of recurrent policies. Introduce:

- a base class, `BaseRecurrentActorCriticPolicy`, from which all recurrent actor-critics derive
- keep the old `ActorCriticPolicy` and its children, so old tests still pass
- Add the `RecurrentFeaturesExtractorActorCriticPolicy`, which takes a `RecurrentFeaturesExtractor` instead of a `FeaturesExtractor` as its way to process observations.