### PR TITLE
Correctly complain about missing attributes in Pytree dataclasses

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ parameters:
   docker_img_version:
     # Docker image version for running tests.
     type: string
-    default: "03a594c"
+    default: "0abb65f"
 
 workflows:
   test-jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            /workspace/dist_test.py -c circleci_worker --worker-out-dir /workspace/test-results . -k 'not test_save_load_large_model'
+            /workspace/dist_test.py --worker-out-dir /workspace/test-results . -k 'not test_save_load_large_model'
           environment:
             OMP_NUM_THREADS: "2"
       - save-worker-test-results

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ lint:
 
 format:
 	# Sort imports
-	ruff --select I ${LINT_PATHS} --fix
+	ruff --fix .
 	# Reformat using black
 	black ${LINT_PATHS}
 

--- a/stable_baselines3/common/pytree_dataclass.py
+++ b/stable_baselines3/common/pytree_dataclass.py
@@ -1,5 +1,6 @@
 import dataclasses
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     ClassVar,
@@ -153,16 +154,31 @@ class _PyTreeDataclassBase(CustomTreeNode[T], metaclass=_PyTreeDataclassMeta):
         return cls(**dict(zip_strict(cls._names(), children)))
 
 
-@dataclass_transform(frozen_default=True)  # pytype: disable=not-supported-yet
-class FrozenPyTreeDataclass(_PyTreeDataclassBase[T], Generic[T], frozen=True):
-    "Abstract class for immutable dataclass PyTrees"
-    ...
+if TYPE_CHECKING:
+    # Remove _PyTreeDataclassBase as a parent during type checking, so pyright correctly complains about missing
+    # attributes. I don't know *why* this works.
 
+    @dataclass_transform(frozen_default=True)  # pytype: disable=not-supported-yet
+    class FrozenPyTreeDataclass(CustomTreeNode[T], Generic[T], frozen=True):
+        "Abstract class for immutable dataclass PyTrees"
+        ...
 
-@dataclass_transform(frozen_default=False)  # pytype: disable=not-supported-yet
-class MutablePyTreeDataclass(_PyTreeDataclassBase[T], Generic[T], frozen=False):
-    "Abstract class for mutable dataclass PyTrees"
-    ...
+    @dataclass_transform(frozen_default=False)  # pytype: disable=not-supported-yet
+    class MutablePyTreeDataclass(CustomTreeNode[T], Generic[T], frozen=False):
+        "Abstract class for mutable dataclass PyTrees"
+        ...
+
+else:
+
+    @dataclass_transform(frozen_default=True)  # pytype: disable=not-supported-yet
+    class FrozenPyTreeDataclass(_PyTreeDataclassBase[T], Generic[T], frozen=True):
+        "Abstract class for immutable dataclass PyTrees"
+        ...
+
+    @dataclass_transform(frozen_default=False)  # pytype: disable=not-supported-yet
+    class MutablePyTreeDataclass(_PyTreeDataclassBase[T], Generic[T], frozen=False):
+        "Abstract class for mutable dataclass PyTrees"
+        ...
 
 
 # Manually expand the concrete type PyTree[th.Tensor] to make mypy happy.

--- a/stable_baselines3/common/pytree_dataclass.py
+++ b/stable_baselines3/common/pytree_dataclass.py
@@ -1,5 +1,6 @@
 import dataclasses
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     ClassVar,
@@ -152,16 +153,31 @@ class _PyTreeDataclassBase(CustomTreeNode[T], metaclass=_PyTreeDataclassMeta):
         return cls(**dict(zip_strict(cls._names(), children)))
 
 
-@dataclass_transform(frozen_default=True)  # pytype: disable=not-supported-yet
-class FrozenPyTreeDataclass(_PyTreeDataclassBase[T], Generic[T], frozen=True):
-    "Abstract class for immutable dataclass PyTrees"
-    ...
+if TYPE_CHECKING:
+    # Remove _PyTreeDataclassBase as a parent during type checking, so pyright correctly complains about missing
+    # attributes. I don't know *why* this works.
 
+    @dataclass_transform(frozen_default=True)  # pytype: disable=not-supported-yet
+    class FrozenPyTreeDataclass(CustomTreeNode[T], Generic[T], frozen=True):
+        "Abstract class for immutable dataclass PyTrees"
+        ...
 
-@dataclass_transform(frozen_default=False)  # pytype: disable=not-supported-yet
-class MutablePyTreeDataclass(_PyTreeDataclassBase[T], Generic[T], frozen=False):
-    "Abstract class for mutable dataclass PyTrees"
-    ...
+    @dataclass_transform(frozen_default=False)  # pytype: disable=not-supported-yet
+    class MutablePyTreeDataclass(CustomTreeNode[T], Generic[T], frozen=False):
+        "Abstract class for mutable dataclass PyTrees"
+        ...
+
+else:
+
+    @dataclass_transform(frozen_default=True)  # pytype: disable=not-supported-yet
+    class FrozenPyTreeDataclass(_PyTreeDataclassBase[T], Generic[T], frozen=True):
+        "Abstract class for immutable dataclass PyTrees"
+        ...
+
+    @dataclass_transform(frozen_default=False)  # pytype: disable=not-supported-yet
+    class MutablePyTreeDataclass(_PyTreeDataclassBase[T], Generic[T], frozen=False):
+        "Abstract class for mutable dataclass PyTrees"
+        ...
 
 
 # Manually expand the concrete type PyTree[th.Tensor] to make mypy happy.

--- a/stable_baselines3/common/pytree_dataclass.py
+++ b/stable_baselines3/common/pytree_dataclass.py
@@ -5,7 +5,6 @@ from typing import (
     ClassVar,
     Dict,
     Generic,
-    List,
     Optional,
     Sequence,
     Tuple,

--- a/stable_baselines3/common/pytree_dataclass.py
+++ b/stable_baselines3/common/pytree_dataclass.py
@@ -169,10 +169,8 @@ class MutablePyTreeDataclass(_PyTreeDataclassBase[T], Generic[T], frozen=False):
 # See links in https://github.com/metaopt/optree/issues/6, generic recursive types are not currently supported in mypy
 TensorTree = Union[
     th.Tensor,
-    Tuple["TensorTree", ...],
-    Tuple[th.Tensor, ...],
-    List["TensorTree"],
-    List[th.Tensor],
+    Sequence["TensorTree"],
+    Sequence[th.Tensor],
     Dict[Any, "TensorTree"],
     Dict[Any, th.Tensor],
     CustomTreeNode[th.Tensor],

--- a/stable_baselines3/common/pytree_dataclass.py
+++ b/stable_baselines3/common/pytree_dataclass.py
@@ -123,7 +123,7 @@ if TYPE_CHECKING:
     # For some reason, having an exotic metaclass confuses Pyright, which then doesn't report accessing non-existing
     # attributes of the dataclasses below as an error. Thus we remove the metaclass for type-checking purposes.
 
-    class _PyTreeDataclassBase(CustomTreeNode[T]):
+    class _PyTreeDataclassBase(CustomTreeNode[T], Generic[T]):
         """Dummy class without _PyTreeDataclassMeta as a metaclass."""
 
         def __init_subclass__(cls, frozen: bool = False) -> None:  # Allow passing `frozen=` in subclasses
@@ -140,7 +140,7 @@ if TYPE_CHECKING:
 
 else:
 
-    class _PyTreeDataclassBase(CustomTreeNode[T], metaclass=_PyTreeDataclassMeta):
+    class _PyTreeDataclassBase(CustomTreeNode[T], Generic[T], metaclass=_PyTreeDataclassMeta):
         """
         Provides utility methods common to both MutablePyTreeDataclass and FrozenPyTreeDataclass.
 

--- a/stable_baselines3/common/recurrent/buffers.py
+++ b/stable_baselines3/common/recurrent/buffers.py
@@ -188,8 +188,7 @@ class RecurrentRolloutBuffer(RolloutBuffer):
             values=th.zeros(batch_shape, dtype=th.float32, device=device),
             log_probs=th.zeros(batch_shape, dtype=th.float32, device=device),
             hidden_states=tree_map(
-                lambda x: th.zeros((self.buffer_size, x.shape[0], self.n_envs, *x.shape[1:]), dtype=x.dtype, device=device),
-                hidden_state_example,
+                lambda x: th.zeros((self.buffer_size, *x.shape), dtype=x.dtype, device=device), hidden_state_example
             ),
         )
 

--- a/stable_baselines3/common/recurrent/policies.py
+++ b/stable_baselines3/common/recurrent/policies.py
@@ -315,11 +315,6 @@ class RecurrentActorCriticPolicy(BaseRecurrentActorCriticPolicy):
                 **self.lstm_kwargs,
             )
 
-        # Setup optimizer with initial learning rate
-        self.optimizer = self.optimizer_class(
-            self.parameters(), lr=lr_schedule(1), **self.optimizer_kwargs  # type: ignore[call-arg]
-        )
-
     def _build_mlp_extractor(self) -> None:
         """
         Create the policy and value networks.

--- a/stable_baselines3/ppo_recurrent/ppo_recurrent.py
+++ b/stable_baselines3/ppo_recurrent/ppo_recurrent.py
@@ -205,7 +205,7 @@ class RecurrentPPO(OnPolicyAlgorithm):
         # if not isinstance(self.policy, RecurrentActorCriticPolicy):
         #     raise ValueError("Policy must subclass RecurrentActorCriticPolicy")
 
-        hidden_state_example = self.policy.recurrent_initial_state(n_envs=None, device=self.device)
+        hidden_state_example = self.policy.recurrent_initial_state(n_envs=self.n_envs, device=self.device)
 
         self.rollout_buffer = RecurrentRolloutBuffer(
             self.n_steps,

--- a/stable_baselines3/ppo_recurrent/ppo_recurrent.py
+++ b/stable_baselines3/ppo_recurrent/ppo_recurrent.py
@@ -339,7 +339,7 @@ class RecurrentPPO(OnPolicyAlgorithm):
 
         with th.no_grad():
             # Compute value for the last timestep
-            episode_starts = th.as_tensor(dones).to(dtype=th.bool, device=self.device)
+            dones = episode_starts = th.as_tensor(dones).to(dtype=th.bool, device=self.device)
             values = self.policy.predict_values(obs_as_tensor(new_obs, self.device), lstm_states, episode_starts)
 
         rollout_buffer.compute_returns_and_advantage(last_values=values, dones=dones)

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -140,16 +140,15 @@ def test_device_buffer(replay_buffer_cls, device):
         RecurrentRolloutBuffer: DummyDictEnv,
     }[replay_buffer_cls]
     env = make_vec_env(env)
+    hidden_states_shape = HIDDEN_STATES_EXAMPLE["a"]["b"].shape
+    N_ENVS_HIDDEN_STATES = {"a": {"b": th.zeros((hidden_states_shape[0], env.num_envs, *hidden_states_shape[1:]))}}
 
     if replay_buffer_cls == RecurrentRolloutBuffer:
         buffer = RecurrentRolloutBuffer(
-            EP_LENGTH, env.observation_space, env.action_space, hidden_state_example=HIDDEN_STATES_EXAMPLE, device=device
+            EP_LENGTH, env.observation_space, env.action_space, hidden_state_example=N_ENVS_HIDDEN_STATES, device=device
         )
     else:
         buffer = replay_buffer_cls(EP_LENGTH, env.observation_space, env.action_space, device=device)
-
-    hidden_states_shape = HIDDEN_STATES_EXAMPLE["a"]["b"].shape
-    N_ENVS_HIDDEN_STATES = {"a": {"b": th.zeros((hidden_states_shape[0], env.num_envs, *hidden_states_shape[1:]))}}
 
     # Interract and store transitions
     obs = env.reset()

--- a/tests/test_type_aliases.py
+++ b/tests/test_type_aliases.py
@@ -5,7 +5,7 @@ import pytest
 from stable_baselines3.common.type_aliases import check_cast, non_null
 
 
-def test_non_null():
+def test_non_null() -> None:
     for a in (1, "a", [2]):
         assert non_null(a) == a
 
@@ -13,8 +13,8 @@ def test_non_null():
         non_null(None)
 
 
-def test_check_cast():
-    EMPTY_DICT = {}
+def test_check_cast() -> None:
+    EMPTY_DICT: dict = {}
     assert check_cast(dict, EMPTY_DICT) is EMPTY_DICT
     assert check_cast(dict[str, int], EMPTY_DICT) is EMPTY_DICT
     assert check_cast(Dict[str, int], EMPTY_DICT) is EMPTY_DICT


### PR DESCRIPTION
Make the type checker complain if you access an attribute of a dataclass that doesn't exist.