### PR TITLE
Reduce tensor copies in RecurrentRolloutBuffer

### DIFF
--- a/stable_baselines3/common/distributions.py
+++ b/stable_baselines3/common/distributions.py
@@ -115,10 +115,7 @@ def sum_independent_dims(tensor: th.Tensor) -> th.Tensor:
     :param tensor: shape: (n_batch, n_actions) or (n_batch,)
     :return: shape: (n_batch,)
     """
-    if len(tensor.shape) > 1:
-        tensor = tensor.sum(dim=-1)
-    else:
-        tensor = tensor.sum()
+    tensor = tensor.sum(dim=-1)
     return tensor
 
 

--- a/stable_baselines3/common/distributions.py
+++ b/stable_baselines3/common/distributions.py
@@ -116,7 +116,7 @@ def sum_independent_dims(tensor: th.Tensor) -> th.Tensor:
     :return: shape: (n_batch,)
     """
     if len(tensor.shape) > 1:
-        tensor = tensor.sum(dim=1)
+        tensor = tensor.sum(dim=-1)
     else:
         tensor = tensor.sum()
     return tensor
@@ -236,7 +236,7 @@ class SquashedDiagGaussianDistribution(DiagGaussianDistribution):
         log_prob = super().log_prob(gaussian_actions)
         # Squash correction (from original SAC implementation)
         # this comes from the fact that tanh is bijective and differentiable
-        log_prob -= th.sum(th.log(1 - actions**2 + self.epsilon), dim=1)
+        log_prob -= th.sum(th.log(1 - actions**2 + self.epsilon), dim=-1)
         return log_prob
 
     def entropy(self) -> Optional[th.Tensor]:
@@ -298,7 +298,7 @@ class CategoricalDistribution(Distribution):
         return self.distribution.sample()
 
     def mode(self) -> th.Tensor:
-        return th.argmax(self.distribution.probs, dim=1)
+        return th.argmax(self.distribution.probs, dim=-1)
 
     def actions_from_params(self, action_logits: th.Tensor, deterministic: bool = False) -> th.Tensor:
         # Update the proba distribution
@@ -339,14 +339,14 @@ class MultiCategoricalDistribution(Distribution):
     def proba_distribution(
         self: SelfMultiCategoricalDistribution, action_logits: th.Tensor
     ) -> SelfMultiCategoricalDistribution:
-        self.distribution = [Categorical(logits=split) for split in th.split(action_logits, tuple(self.action_dims), dim=1)]
+        self.distribution = [Categorical(logits=split) for split in th.split(action_logits, tuple(self.action_dims), dim=-1)]
         return self
 
     def log_prob(self, actions: th.Tensor) -> th.Tensor:
         # Extract each discrete action and compute log prob for their respective distributions
         return th.stack(
-            [dist.log_prob(action) for dist, action in zip(self.distribution, th.unbind(actions, dim=1))], dim=1
-        ).sum(dim=1)
+            [dist.log_prob(action) for dist, action in zip(self.distribution, th.unbind(actions, dim=-1))], dim=-1
+        ).sum(dim=-1)
 
     def entropy(self) -> th.Tensor:
         return th.stack([dist.entropy() for dist in self.distribution], dim=1).sum(dim=1)
@@ -355,7 +355,7 @@ class MultiCategoricalDistribution(Distribution):
         return th.stack([dist.sample() for dist in self.distribution], dim=1)
 
     def mode(self) -> th.Tensor:
-        return th.stack([th.argmax(dist.probs, dim=1) for dist in self.distribution], dim=1)
+        return th.stack([th.argmax(dist.probs, dim=-1) for dist in self.distribution], dim=-1)
 
     def actions_from_params(self, action_logits: th.Tensor, deterministic: bool = False) -> th.Tensor:
         # Update the proba distribution
@@ -399,7 +399,7 @@ class BernoulliDistribution(Distribution):
         return self.distribution.log_prob(actions).sum(dim=1)
 
     def entropy(self) -> th.Tensor:
-        return self.distribution.entropy().sum(dim=1)
+        return self.distribution.entropy().sum(dim=-1)
 
     def sample(self) -> th.Tensor:
         return self.distribution.sample()
@@ -563,7 +563,7 @@ class StateDependentNoiseDistribution(Distribution):
 
         if self.bijector is not None:
             # Squash correction (from original SAC implementation)
-            log_prob -= th.sum(self.bijector.log_prob_correction(gaussian_actions), dim=1)
+            log_prob -= th.sum(self.bijector.log_prob_correction(gaussian_actions), dim=-1)
         return log_prob
 
     def entropy(self) -> Optional[th.Tensor]:
@@ -593,10 +593,10 @@ class StateDependentNoiseDistribution(Distribution):
             return latent_sde @ self.exploration_mat
         # Use batch matrix multiplication for efficient computation
         # (batch_size, n_features) -> (batch_size, 1, n_features)
-        latent_sde = latent_sde.unsqueeze(dim=1)
+        latent_sde = latent_sde.unsqueeze(dim=-1)
         # (batch_size, 1, n_actions)
         noise = th.bmm(latent_sde, self.exploration_matrices)
-        return noise.squeeze(dim=1)
+        return noise.squeeze(dim=-1)
 
     def actions_from_params(
         self, mean_actions: th.Tensor, log_std: th.Tensor, latent_sde: th.Tensor, deterministic: bool = False
@@ -705,8 +705,8 @@ def kl_divergence(dist_true: Distribution, dist_pred: Distribution) -> th.Tensor
         assert np.allclose(dist_pred.action_dims, dist_true.action_dims), "Error: distributions must have the same input space"
         return th.stack(
             [th.distributions.kl_divergence(p, q) for p, q in zip(dist_true.distribution, dist_pred.distribution)],
-            dim=1,
-        ).sum(dim=1)
+            dim=-1,
+        ).sum(dim=-1)
 
     # Use the PyTorch kl_divergence implementation
     else:

--- a/stable_baselines3/common/distributions.py
+++ b/stable_baselines3/common/distributions.py
@@ -353,10 +353,10 @@ class MultiCategoricalDistribution(Distribution):
         ).sum(dim=-1)
 
     def entropy(self) -> th.Tensor:
-        return th.stack([dist.entropy() for dist in self.distribution], dim=1).sum(dim=1)
+        return th.stack([dist.entropy() for dist in self.distribution], dim=-1).sum(dim=-1)
 
     def sample(self) -> th.Tensor:
-        return th.stack([dist.sample() for dist in self.distribution], dim=1)
+        return th.stack([dist.sample() for dist in self.distribution], dim=-1)
 
     def mode(self) -> th.Tensor:
         for dist in self.distribution:
@@ -402,7 +402,7 @@ class BernoulliDistribution(Distribution):
         return self
 
     def log_prob(self, actions: th.Tensor) -> th.Tensor:
-        return self.distribution.log_prob(actions).sum(dim=1)
+        return self.distribution.log_prob(actions).sum(dim=-1)
 
     def entropy(self) -> th.Tensor:
         return self.distribution.entropy().sum(dim=-1)

--- a/stable_baselines3/common/distributions.py
+++ b/stable_baselines3/common/distributions.py
@@ -547,7 +547,7 @@ class StateDependentNoiseDistribution(Distribution):
         """
         # Stop gradient if we don't want to influence the features
         self._latent_sde = latent_sde if self.learn_features else latent_sde.detach()
-        variance = th.mm(self._latent_sde**2, self.get_std(log_std) ** 2)
+        variance = (self._latent_sde**2) @ (self.get_std(log_std) ** 2)
         self.distribution = Normal(mean_actions, th.sqrt(variance + self.epsilon))
         return self
 
@@ -590,7 +590,7 @@ class StateDependentNoiseDistribution(Distribution):
         latent_sde = latent_sde if self.learn_features else latent_sde.detach()
         # Default case: only one exploration matrix
         if len(latent_sde) == 1 or len(latent_sde) != len(self.exploration_matrices):
-            return th.mm(latent_sde, self.exploration_mat)
+            return latent_sde @ self.exploration_mat
         # Use batch matrix multiplication for efficient computation
         # (batch_size, n_features) -> (batch_size, 1, n_features)
         latent_sde = latent_sde.unsqueeze(dim=1)

--- a/stable_baselines3/common/evaluation.py
+++ b/stable_baselines3/common/evaluation.py
@@ -84,15 +84,13 @@ def evaluate_policy(
 
     observations = env.reset()
     observations = obs_as_tensor(observations, model.device)
-    episode_counts = th.zeros(n_envs, dtype=th.int64, device=model.device)
+    episode_counts = th.zeros(n_envs, dtype=th.int64, device="cpu")
     # Divides episodes among different sub environments in the vector as evenly as possible
-    episode_count_targets = th.tensor(
-        [(n_eval_episodes + i) // n_envs for i in range(n_envs)], dtype=th.int64, device=model.device
-    )
+    episode_count_targets = th.tensor([(n_eval_episodes + i) // n_envs for i in range(n_envs)], dtype=th.int64, device="cpu")
 
     states = None
-    current_rewards = th.zeros(n_envs, dtype=th.float32, device=model.device)
-    current_lengths = th.zeros(n_envs, dtype=th.int64, device=model.device)
+    current_rewards = th.zeros(n_envs, dtype=th.float32, device="cpu")
+    current_lengths = th.zeros(n_envs, dtype=th.int64, device="cpu")
     episode_starts = th.ones((env.num_envs,), dtype=th.bool, device=model.device)
     while (episode_counts < episode_count_targets).any():
         actions, states = model.predict(
@@ -102,7 +100,7 @@ def evaluate_policy(
             deterministic=deterministic,
         )
         new_observations, rewards, dones, infos = env.step(actions)
-        current_rewards += rewards
+        current_rewards += rewards.to(current_rewards)
         current_lengths += 1
         for i in range(n_envs):
             if episode_counts[i] < episode_count_targets[i]:

--- a/stable_baselines3/common/evaluation.py
+++ b/stable_baselines3/common/evaluation.py
@@ -84,6 +84,10 @@ def evaluate_policy(
 
     observations = env.reset()
     observations = obs_as_tensor(observations, model.device)
+
+    # Hardcode episode counts and the reward accumulators to use CPU. They're used for bookkeeping and don't involve
+    # much computation.
+
     episode_counts = th.zeros(n_envs, dtype=th.int64, device="cpu")
     # Divides episodes among different sub environments in the vector as evenly as possible
     episode_count_targets = th.tensor([(n_eval_episodes + i) // n_envs for i in range(n_envs)], dtype=th.int64, device="cpu")

--- a/stable_baselines3/common/pytree_dataclass.py
+++ b/stable_baselines3/common/pytree_dataclass.py
@@ -282,7 +282,7 @@ def tree_empty(
 
 def tree_index(
     tree: ConcreteTensorTree,
-    idx: TensorIndex,
+    idx: TensorIndex | tuple[TensorIndex, ...],
     *,
     is_leaf: None | Callable[[TensorTree], bool] = None,
     none_is_leaf: bool = False,

--- a/stable_baselines3/common/recurrent/buffers.py
+++ b/stable_baselines3/common/recurrent/buffers.py
@@ -186,7 +186,7 @@ class RecurrentRolloutBuffer(RolloutBuffer):
             advantages=self.advantages[idx],
             returns=self.returns[idx],
             hidden_states=tree_index(self.data.hidden_states, hidden_states_idx),  # Return only the first hidden state
-            episode_starts=self.data.episode_starts,
+            episode_starts=self.data.episode_starts[idx],
         )
 
 

--- a/stable_baselines3/common/recurrent/buffers.py
+++ b/stable_baselines3/common/recurrent/buffers.py
@@ -14,7 +14,6 @@ from stable_baselines3.common.pytree_dataclass import (
     tree_map,
 )
 from stable_baselines3.common.recurrent.type_aliases import (
-    ActorCriticStates,
     RecurrentRolloutBufferData,
     RecurrentRolloutBufferSamples,
 )

--- a/stable_baselines3/common/recurrent/buffers.py
+++ b/stable_baselines3/common/recurrent/buffers.py
@@ -1,7 +1,6 @@
 import dataclasses
 import logging
-from functools import partial
-from typing import Callable, Generator, Optional, Tuple, Union
+from typing import Generator, Optional, Tuple, Union
 
 import numpy as np
 import torch as th
@@ -15,111 +14,14 @@ from stable_baselines3.common.pytree_dataclass import (
     tree_map,
 )
 from stable_baselines3.common.recurrent.type_aliases import (
+    ActorCriticStates,
     RecurrentRolloutBufferData,
     RecurrentRolloutBufferSamples,
 )
 from stable_baselines3.common.utils import get_device
-from stable_baselines3.common.vec_env import VecNormalize
 from stable_baselines3.common.vec_env.util import as_torch_dtype
 
 log = logging.getLogger(__name__)
-
-
-def pad(
-    seq_start_indices: th.Tensor,
-    seq_end_indices: th.Tensor,
-    tensor: th.Tensor,
-    padding_value: float = 0.0,
-) -> th.Tensor:
-    """
-    Chunk sequences and pad them to have constant dimensions.
-
-    :param seq_start_indices: Indices of the transitions that start a sequence
-    :param seq_end_indices: Indices of the transitions that end a sequence
-    :param tensor: Tensor of shape (batch_size, *tensor_shape)
-    :param padding_value: Value used to pad sequence to the same length
-        (zero padding by default)
-    :return: (n_seq, max_length, *tensor_shape)
-    """
-    # Create sequences given start and end
-    seq = [tensor[start : end + 1] for start, end in zip(seq_start_indices, seq_end_indices)]
-    return th.nn.utils.rnn.pad_sequence(seq, batch_first=True, padding_value=padding_value)
-
-
-def pad_and_flatten(
-    seq_start_indices: th.Tensor,
-    seq_end_indices: th.Tensor,
-    tensor: th.Tensor,
-    padding_value: float = 0.0,
-) -> th.Tensor:
-    """
-    Pad and flatten the sequences of scalar values,
-    while keeping the sequence order.
-    From (batch_size, 1) to (n_seq, max_length, 1) -> (n_seq * max_length,)
-
-    :param seq_start_indices: Indices of the transitions that start a sequence
-    :param seq_end_indices: Indices of the transitions that end a sequence
-    :param tensor: Tensor of shape (max_length, n_seq, 1)
-    :param padding_value: Value used to pad sequence to the same length
-        (zero padding by default)
-    :return: (n_seq * max_length,) aka (padded_batch_size,)
-    """
-    return pad(seq_start_indices, seq_end_indices, tensor, padding_value).flatten()
-
-
-def create_sequencers(
-    episode_starts: th.Tensor,
-    env_change: th.Tensor,
-    n_envs: int,
-) -> Tuple[th.Tensor, int, Callable, Callable]:
-    """
-    Create the utility function to chunk data into
-    sequences and pad them to create fixed size tensors.
-
-    :param episode_starts: Indices where an episode starts
-    :param env_change: Indices where the data collected
-        come from a different env (when using multiple env for data collection)
-    :return: Indices of the transitions that start a sequence,
-        pad and pad_and_flatten utilities tailored for this batch
-        (sequence starts and ends indices are fixed)
-    """
-    # Create sequence if env changes too
-    seq_start = (episode_starts | env_change).flatten()
-    # First index is always the beginning of a sequence
-    seq_start[0] = True
-    # Retrieve indices of sequence starts
-    seq_start_indices = th.argwhere(seq_start).squeeze(1)
-    # End of sequence are just before sequence starts
-    # Last index is also always end of a sequence
-    seq_end_indices = th.cat(
-        [
-            (seq_start_indices - 1)[1:],
-            th.tensor([len(episode_starts)], device=seq_start_indices.device, dtype=seq_start_indices.dtype),
-        ]
-    )
-
-    lengths_except_last = seq_start_indices[1:] - seq_start_indices[:-1]
-    last_length = len(episode_starts) - seq_start_indices[-1].item()
-    if lengths_except_last.numel():
-        max_length = int(max(lengths_except_last.max().item(), last_length))
-        mean_length = float(lengths_except_last.sum().item() + last_length) / (len(lengths_except_last) + 1)
-    else:
-        max_length = int(last_length)
-        mean_length = float(last_length)
-
-    n_episodes = len(lengths_except_last) + 1
-    if n_episodes > n_envs * 3:
-        log.warn(
-            f"Episodes are too short. Probably this is an error. You should reduce the number of steps collected per "
-            f"step by RecurrentPPO algorithm, or use an environment with longer episodes. "
-            f"{n_episodes=}, {n_envs=}, {mean_length=}, {max_length=}"
-        )
-
-    # Create padding method for this minibatch
-    # to avoid repeating arguments (seq_start_indices, seq_end_indices)
-    local_pad = partial(pad, seq_start_indices, seq_end_indices)
-    local_pad_and_flatten = partial(pad_and_flatten, seq_start_indices, seq_end_indices)
-    return seq_start_indices, max_length, local_pad, local_pad_and_flatten
 
 
 def space_to_example(
@@ -251,78 +153,40 @@ class RecurrentRolloutBuffer(RolloutBuffer):
     ) -> Generator[RecurrentRolloutBufferSamples, None, None]:
         assert self.full, "Rollout buffer must be full before sampling from it"
 
-        hidden_states = tree_map(lambda x: x.swapaxes(1, 2), self.data.hidden_states)
-        data: RecurrentRolloutBufferData = tree_map(
-            self.swap_and_flatten, dataclasses.replace(self.data, hidden_states=hidden_states)  # type: ignore[misc]
-        )
-        returns = self.swap_and_flatten(self.returns)
-        advantages = self.swap_and_flatten(self.advantages)
-
         # Return everything, don't create minibatches
         if batch_size is None:
             batch_size = self.buffer_size * self.n_envs
 
-        # Sampling strategy that allows any mini batch size but requires
-        # more complexity and use of padding
-        # Trick to shuffle a bit: keep the sequence order
-        # but split the indices in two
-        split_index = int(np.random.randint(self.buffer_size * self.n_envs))
-        indices = th.arange(self.buffer_size * self.n_envs)
-        indices = th.cat((indices[split_index:], indices[:split_index]))
+        if batch_size % self.buffer_size != 0:
+            raise ValueError(f"Batch size must be divisible by sequence length, but {batch_size=} and len={self.buffer_size}")
 
-        env_change = th.zeros((self.buffer_size, self.n_envs), dtype=th.bool, device=self.device)
-        # Flag first timestep as change of environment
-        env_change[0, :] = True
-        env_change = self.swap_and_flatten(env_change)
+        indices = th.randperm(self.n_envs)
+        adjusted_batch_size = batch_size // self.buffer_size
+
+        if adjusted_batch_size >= self.n_envs:
+            yield self._get_samples(slice(None))
 
         start_idx = 0
-        while start_idx < self.buffer_size * self.n_envs:
-            batch_inds = indices[start_idx : start_idx + batch_size]
-            yield self._get_samples(data, returns, advantages, batch_inds, env_change)
-            start_idx += batch_size
+        while start_idx < self.n_envs:
+            yield self._get_samples(indices[start_idx : start_idx + adjusted_batch_size])
+            start_idx += adjusted_batch_size
 
     def _get_samples(  # type: ignore[override]
         self,
-        data: RecurrentRolloutBufferData,
-        returns: th.Tensor,
-        advantages: th.Tensor,
-        batch_inds: th.Tensor,
-        env_change: th.Tensor,
-        env: Optional[VecNormalize] = None,
+        batch_inds: Union[slice, th.Tensor],
     ) -> RecurrentRolloutBufferSamples:
-        # Retrieve sequence starts and utility function
-        local_seq_start_indices, max_length, local_pad, local_pad_and_flatten = create_sequencers(
-            data.episode_starts[batch_inds], env_change[batch_inds], self.n_envs
-        )
-
-        # Number of sequences
-        n_seq = len(local_seq_start_indices)
-        padded_batch_size = n_seq * max_length
-        # We retrieve the RNN hidden states that will allow
-        # to properly initialize the RNN at the beginning of each sequence
-        # NOTE: this only gets the first index. For transformers we'll have to get *all* previous KV-vectors.
-
-        rnn_states = tree_map(
-            lambda x: self.to_device(x[batch_inds][local_seq_start_indices].swapaxes(0, 1)).contiguous(), data.hidden_states
-        )
-
-        observations = tree_map(
-            lambda x, example: local_pad(x[batch_inds]).view(padded_batch_size, *example.shape),
-            data.observations,
-            self.observation_space_example,
-        )
+        idx = (slice(None), batch_inds)
+        hidden_states_idx = (0, slice(None), batch_inds)
 
         return RecurrentRolloutBufferSamples(
-            # (batch_size, obs_dim) -> (n_seq, max_length, obs_dim) -> (n_seq * max_length, obs_dim)
-            observations=observations,
-            actions=local_pad(data.actions[batch_inds]).view(padded_batch_size, *data.actions.shape[1:]),
-            old_values=local_pad_and_flatten(data.values[batch_inds]),
-            old_log_prob=local_pad_and_flatten(data.log_probs[batch_inds]),
-            advantages=local_pad_and_flatten(advantages[batch_inds]),
-            returns=local_pad_and_flatten(returns[batch_inds]),
-            hidden_states=rnn_states,
-            episode_starts=local_pad_and_flatten(data.episode_starts[batch_inds]),
-            mask=local_pad_and_flatten(th.ones(returns[batch_inds].shape, dtype=th.bool, device=self.device)),
+            observations=tree_index(self.data.observations, idx),
+            actions=self.data.actions[idx],
+            old_values=self.data.values[idx],
+            old_log_prob=self.data.log_probs[idx],
+            advantages=self.advantages[idx],
+            returns=self.returns[idx],
+            hidden_states=tree_index(self.data.hidden_states, hidden_states_idx),  # Return only the first hidden state
+            episode_starts=self.data.episode_starts,
         )
 
 

--- a/stable_baselines3/common/recurrent/policies.py
+++ b/stable_baselines3/common/recurrent/policies.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, Generic, List, Optional, Tuple, Type, Union
 
 import torch as th
 from gymnasium import spaces
+from optree import tree_map
 from torch import nn
 
 from stable_baselines3.common.distributions import Distribution
@@ -342,6 +343,7 @@ class RecurrentActorCriticPolicy(BaseRecurrentActorCriticPolicy):
     def _recurrent_latent_pi_and_vf(
         self, obs: TorchGymObs, state: ActorCriticStates[LSTMRecurrentState], episode_starts: th.Tensor
     ) -> Tuple[Tuple[th.Tensor, th.Tensor], ActorCriticStates[LSTMRecurrentState]]:
+        obs = tree_map(lambda x: x.view(-1, *x.shape[episode_starts.ndim :]), obs)  # type: ignore[assignment]
         features = self.extract_features(obs)
         pi_features: th.Tensor
         vf_features: th.Tensor
@@ -351,6 +353,10 @@ class RecurrentActorCriticPolicy(BaseRecurrentActorCriticPolicy):
         else:
             assert isinstance(features, tuple)
             pi_features, vf_features = features
+
+        pi_features = pi_features.view(*episode_starts.shape, *pi_features.shape[1:])
+        vf_features = vf_features.view(*episode_starts.shape, *vf_features.shape[1:])
+
         latent_pi, lstm_states_pi = self.lstm_actor.forward(pi_features, state.pi, episode_starts)
         latent_vf, lstm_states_vf = self._recurrent_latent_vf_from_features(vf_features, state, episode_starts)
         if lstm_states_vf is None:
@@ -375,8 +381,11 @@ class RecurrentActorCriticPolicy(BaseRecurrentActorCriticPolicy):
     def _recurrent_latent_vf_nostate(
         self, obs: TorchGymObs, state: ActorCriticStates[LSTMRecurrentState], episode_starts: th.Tensor
     ) -> th.Tensor:
+        obs = tree_map(lambda x: x.view(-1, *x.shape[episode_starts.ndim :]), obs)  # type: ignore[assignment]
         vf_features: th.Tensor = super(ActorCriticPolicy, self).extract_features(obs, self.vf_features_extractor)
-        return self._recurrent_latent_vf_from_features(vf_features, state, episode_starts)[0]
+        vf_features = vf_features.view(*episode_starts.shape, *vf_features.shape[1:])
+        latent_vf, _ = self._recurrent_latent_vf_from_features(vf_features, state, episode_starts)
+        return latent_vf
 
     def forward(  # type: ignore[override]
         self,

--- a/stable_baselines3/common/recurrent/policies.py
+++ b/stable_baselines3/common/recurrent/policies.py
@@ -343,7 +343,7 @@ class RecurrentActorCriticPolicy(BaseRecurrentActorCriticPolicy):
     def _recurrent_latent_pi_and_vf(
         self, obs: TorchGymObs, state: ActorCriticStates[LSTMRecurrentState], episode_starts: th.Tensor
     ) -> Tuple[Tuple[th.Tensor, th.Tensor], ActorCriticStates[LSTMRecurrentState]]:
-        obs = tree_map(lambda x: x.view(-1, *x.shape[episode_starts.ndim :]), obs)  # type: ignore[assignment]
+        obs = tree_map(lambda x: x.view(-1, *x.shape[episode_starts.ndim :]), obs)  # type: ignore[assignment,arg-type]
         features = self.extract_features(obs)
         pi_features: th.Tensor
         vf_features: th.Tensor
@@ -381,7 +381,7 @@ class RecurrentActorCriticPolicy(BaseRecurrentActorCriticPolicy):
     def _recurrent_latent_vf_nostate(
         self, obs: TorchGymObs, state: ActorCriticStates[LSTMRecurrentState], episode_starts: th.Tensor
     ) -> th.Tensor:
-        obs = tree_map(lambda x: x.view(-1, *x.shape[episode_starts.ndim :]), obs)  # type: ignore[assignment]
+        obs = tree_map(lambda x: x.view(-1, *x.shape[episode_starts.ndim :]), obs)  # type: ignore[assignment,arg-type]
         vf_features: th.Tensor = super(ActorCriticPolicy, self).extract_features(obs, self.vf_features_extractor)
         vf_features = vf_features.view(*episode_starts.shape, *vf_features.shape[1:])
         latent_vf, _ = self._recurrent_latent_vf_from_features(vf_features, state, episode_starts)

--- a/stable_baselines3/common/recurrent/torch_layers.py
+++ b/stable_baselines3/common/recurrent/torch_layers.py
@@ -1,11 +1,12 @@
 import abc
+import functools
 from typing import Any, Dict, Generic, Optional, Tuple, TypeVar
 
 import gymnasium as gym
 import torch as th
 
 from stable_baselines3.common.preprocessing import get_flattened_obs_dim
-from stable_baselines3.common.pytree_dataclass import TensorTree, tree_flatten, tree_map
+from stable_baselines3.common.pytree_dataclass import TensorTree, tree_map
 from stable_baselines3.common.recurrent.type_aliases import (
     GRURecurrentState,
     LSTMRecurrentState,
@@ -42,31 +43,37 @@ class RecurrentFeaturesExtractor(BaseFeaturesExtractor, abc.ABC, Generic[Extract
     def _process_sequence(
         rnn: th.nn.RNNBase, inputs: th.Tensor, init_state: RecurrentSubState, episode_starts: th.Tensor
     ) -> Tuple[th.Tensor, RecurrentSubState]:
-        (state_example, *_), _ = tree_flatten(init_state, is_leaf=None)
-        n_layers, batch_sz, *_ = state_example.shape
-        assert n_layers == rnn.num_layers
+        if episode_starts.ndim == 1:
+            seq_len = 1
+            batch_sz = episode_starts.shape[0]
+            inputs = inputs.unsqueeze(0)
+            episode_starts = episode_starts.unsqueeze(0)
+            squeeze_end = True
+        else:
+            assert episode_starts.ndim == 2
+            seq_len, batch_sz = episode_starts.shape
+            squeeze_end = False
 
-        # Batch to sequence
-        # (padded batch size, features_dim) -> (n_seq, max length, features_dim) -> (max length, n_seq, features_dim)
-        seq_len = inputs.shape[0] // batch_sz
-        seq_inputs = inputs.view((batch_sz, seq_len, *inputs.shape[1:])).swapaxes(0, 1)
-        episode_starts = episode_starts.view((batch_sz, seq_len)).swapaxes(0, 1)
-
-        if th.any(episode_starts[1:]):
-            raise NotImplementedError("Resetting state in the middle of a sequence is not supported")
-
-        first_state_is_not_reset = (~episode_starts[0]).contiguous()
-
-        def _reset_state_component(state: th.Tensor) -> th.Tensor:
+        def _reset_state_component(reset_mask: th.Tensor, state: th.Tensor) -> th.Tensor:
             assert state.shape == (rnn.num_layers, batch_sz, rnn.hidden_size)
-            reset_mask = first_state_is_not_reset.view((1, batch_sz, 1))
             return state * reset_mask
 
-        init_state = tree_map(_reset_state_component, init_state)
-        rnn_output, end_state = rnn(seq_inputs, init_state)
+        if th.any(episode_starts[1:]):
+            state_is_not_reset = (~episode_starts).contiguous().view((seq_len, 1, batch_sz, 1))
 
-        # (seq_len, batch_size, ...) -> (batch_size, seq_len, ...) -> (batch_size * seq_len, ...)
-        rnn_output = rnn_output.transpose(0, 1).reshape((batch_sz * seq_len, *rnn_output.shape[2:]))
+            rnn_output_list: list[th.Tensor] = [None] * seq_len  # type: ignore
+            end_state = init_state
+            for t in range(seq_len):
+                end_state = tree_map(functools.partial(_reset_state_component, state_is_not_reset[t]), end_state)
+                rnn_output_list[t], end_state = rnn(inputs[t, None], end_state)
+            rnn_output = th.cat(rnn_output_list, dim=0)
+        else:
+            first_state_is_not_reset = (~episode_starts[0]).contiguous().view((1, batch_sz, 1))
+            init_state = tree_map(lambda s: _reset_state_component(first_state_is_not_reset, s), init_state)
+            rnn_output, end_state = rnn(inputs, init_state)
+
+        if squeeze_end:
+            rnn_output = rnn_output.squeeze(0)
         return rnn_output, end_state
 
 
@@ -112,7 +119,9 @@ class GRUWrappedFeaturesExtractor(RecurrentFeaturesExtractor[ExtractorInput, GRU
     def forward(
         self, observations: ExtractorInput, state: GRURecurrentState, episode_starts: th.Tensor
     ) -> Tuple[th.Tensor, GRURecurrentState]:
+        observations = tree_map(lambda x: x.view(-1, *x.shape[episode_starts.ndim :]), observations)  # type: ignore
         features: th.Tensor = self.base_extractor(observations)
+        features = features.view(*episode_starts.shape, -1)
         return self._process_sequence(self.rnn, features, state, episode_starts)
 
     @property
@@ -203,7 +212,9 @@ class LSTMFlattenExtractor(RecurrentFeaturesExtractor[th.Tensor, LSTMRecurrentSt
     def forward(
         self, observations: th.Tensor, state: LSTMRecurrentState, episode_starts: th.Tensor
     ) -> Tuple[th.Tensor, LSTMRecurrentState]:
+        observations = tree_map(lambda x: x.view(-1, *x.shape[episode_starts.ndim :]), observations)  # type: ignore
         features: th.Tensor = self.base_extractor(observations)
+        features = features.view(*episode_starts.shape, -1)
         return self._process_sequence(self.rnn, features, state, episode_starts)
 
     @property

--- a/stable_baselines3/common/recurrent/torch_layers.py
+++ b/stable_baselines3/common/recurrent/torch_layers.py
@@ -212,7 +212,7 @@ class LSTMFlattenExtractor(RecurrentFeaturesExtractor[th.Tensor, LSTMRecurrentSt
     def forward(
         self, observations: th.Tensor, state: LSTMRecurrentState, episode_starts: th.Tensor
     ) -> Tuple[th.Tensor, LSTMRecurrentState]:
-        observations = tree_map(lambda x: x.view(-1, *x.shape[episode_starts.ndim :]), observations)  # type: ignore
+        observations = observations.view(-1, *observations.shape[episode_starts.ndim :])
         features: th.Tensor = self.base_extractor(observations)
         features = features.view(*episode_starts.shape, -1)
         return self._process_sequence(self.rnn, features, state, episode_starts)

--- a/stable_baselines3/common/recurrent/type_aliases.py
+++ b/stable_baselines3/common/recurrent/type_aliases.py
@@ -35,4 +35,3 @@ class RecurrentRolloutBufferSamples(FrozenPyTreeDataclass[th.Tensor]):
     episode_starts: th.Tensor
     advantages: th.Tensor
     returns: th.Tensor
-    mask: th.Tensor

--- a/stable_baselines3/common/vec_env/base_vec_env.py
+++ b/stable_baselines3/common/vec_env/base_vec_env.py
@@ -40,7 +40,9 @@ def tile_images(images_nhwc: Sequence[th.Tensor] | th.Tensor) -> th.Tensor:  # p
     new_height = int(math.ceil(math.sqrt(n_images)))
     # new_width was named W before
     new_width = int(math.ceil(float(n_images) / new_height))
-    img_nhwc = th.nn.functional.pad(img_nhwc, pad=(max(0, new_height * new_width - n_images), 0, 0, 0))
+    # Pad: c1, c2, w1, w2, h1, h2, n1, n2
+    padding = (0, 0, 0, 0, 0, 0, 0, max(0, new_height * new_width - n_images))
+    img_nhwc = th.nn.functional.pad(img_nhwc, pad=padding)
     # img_HWhwc
     out_image = img_nhwc.reshape((new_height, new_width, height, width, n_channels))
     # img_HhWwc

--- a/stable_baselines3/ppo_recurrent/ppo_recurrent.py
+++ b/stable_baselines3/ppo_recurrent/ppo_recurrent.py
@@ -375,8 +375,7 @@ class RecurrentPPO(OnPolicyAlgorithm):
             for rollout_data in self.rollout_buffer.get(self.batch_size):
                 actions = rollout_data.actions
                 if isinstance(self.action_space, spaces.Discrete):
-                    # Convert discrete action from float to long
-                    actions = rollout_data.actions.long().flatten()
+                    actions = rollout_data.actions.squeeze(-1)
 
                 # Re-sample the noise matrix because the log_std has changed
                 if self.use_sde:
@@ -389,7 +388,7 @@ class RecurrentPPO(OnPolicyAlgorithm):
                     rollout_data.episode_starts,
                 )
 
-                values = values.flatten()
+                values = values.squeeze(-1)
                 # Normalize advantage
                 advantages = rollout_data.advantages
                 if self.normalize_advantage:

--- a/stable_baselines3/ppo_recurrent/ppo_recurrent.py
+++ b/stable_baselines3/ppo_recurrent/ppo_recurrent.py
@@ -392,9 +392,8 @@ class RecurrentPPO(OnPolicyAlgorithm):
                 values = values.flatten()
                 # Normalize advantage
                 advantages = rollout_data.advantages
-                mask = rollout_data.mask
                 if self.normalize_advantage:
-                    advantages = (advantages - advantages[mask].mean()) / (advantages[mask].std() + 1e-8)
+                    advantages = (advantages - advantages.mean()) / (advantages.std() + 1e-8)
 
                 # ratio between old and new policy, should be one at the first iteration
                 ratio = th.exp(log_prob - rollout_data.old_log_prob)
@@ -402,11 +401,11 @@ class RecurrentPPO(OnPolicyAlgorithm):
                 # clipped surrogate loss
                 policy_loss_1 = advantages * ratio
                 policy_loss_2 = advantages * th.clamp(ratio, 1 - clip_range, 1 + clip_range)
-                policy_loss = -th.mean(th.min(policy_loss_1, policy_loss_2)[mask])
+                policy_loss = -th.mean(th.min(policy_loss_1, policy_loss_2))
 
                 # Logging
                 pg_losses.append(policy_loss.item())
-                clip_fraction = th.mean((th.abs(ratio - 1) > clip_range).float()[mask]).item()
+                clip_fraction = th.mean((th.abs(ratio - 1) > clip_range).float()).item()
                 clip_fractions.append(clip_fraction)
 
                 if self.clip_range_vf is None:
@@ -420,16 +419,16 @@ class RecurrentPPO(OnPolicyAlgorithm):
                     )
                 # Value loss using the TD(gae_lambda) target
                 # Mask padded sequences
-                value_loss = th.mean(((rollout_data.returns - values_pred) ** 2)[mask])
+                value_loss = th.mean(((rollout_data.returns - values_pred) ** 2))
 
                 value_losses.append(value_loss.item())
 
                 # Entropy loss favor exploration
                 if entropy is None:
                     # Approximate entropy when no analytical form
-                    entropy_loss = -th.mean(-log_prob[mask])
+                    entropy_loss = -th.mean(-log_prob)
                 else:
-                    entropy_loss = -th.mean(entropy[mask])
+                    entropy_loss = -th.mean(entropy)
 
                 entropy_losses.append(entropy_loss.item())
 
@@ -441,7 +440,7 @@ class RecurrentPPO(OnPolicyAlgorithm):
                 # and Schulman blog: http://joschu.net/blog/kl-approx.html
                 with th.no_grad():
                     log_ratio = log_prob - rollout_data.old_log_prob
-                    approx_kl_div = th.mean(((th.exp(log_ratio) - 1) - log_ratio)[mask]).cpu().numpy()
+                    approx_kl_div = th.mean(((th.exp(log_ratio) - 1) - log_ratio)).cpu().numpy()
                     approx_kl_divs.append(approx_kl_div)
 
                 if self.target_kl is not None and approx_kl_div > 1.5 * self.target_kl:

--- a/stable_baselines3/ppo_recurrent/ppo_recurrent.py
+++ b/stable_baselines3/ppo_recurrent/ppo_recurrent.py
@@ -365,12 +365,12 @@ class RecurrentPPO(OnPolicyAlgorithm):
         entropy_losses = []
         pg_losses, value_losses = [], []
         clip_fractions = []
+        approx_kl_divs = []
 
         continue_training = True
 
         # train for n_epochs epochs
         for epoch in range(self.n_epochs):
-            approx_kl_divs = []
             # Do a complete pass on the rollout buffer
             for rollout_data in self.rollout_buffer.get(self.batch_size):
                 actions = rollout_data.actions
@@ -439,7 +439,7 @@ class RecurrentPPO(OnPolicyAlgorithm):
                 # and Schulman blog: http://joschu.net/blog/kl-approx.html
                 with th.no_grad():
                     log_ratio = log_prob - rollout_data.old_log_prob
-                    approx_kl_div = th.mean((th.exp(log_ratio) - 1) - log_ratio).cpu().numpy()
+                    approx_kl_div = th.mean((th.exp(log_ratio) - 1) - log_ratio).item()
                     approx_kl_divs.append(approx_kl_div)
 
                 if self.target_kl is not None and approx_kl_div > 1.5 * self.target_kl:

--- a/stable_baselines3/ppo_recurrent/ppo_recurrent.py
+++ b/stable_baselines3/ppo_recurrent/ppo_recurrent.py
@@ -418,7 +418,7 @@ class RecurrentPPO(OnPolicyAlgorithm):
                     )
                 # Value loss using the TD(gae_lambda) target
                 # Mask padded sequences
-                value_loss = th.mean(((rollout_data.returns - values_pred) ** 2))
+                value_loss = th.mean((rollout_data.returns - values_pred) ** 2)
 
                 value_losses.append(value_loss.item())
 
@@ -439,7 +439,7 @@ class RecurrentPPO(OnPolicyAlgorithm):
                 # and Schulman blog: http://joschu.net/blog/kl-approx.html
                 with th.no_grad():
                     log_ratio = log_prob - rollout_data.old_log_prob
-                    approx_kl_div = th.mean(((th.exp(log_ratio) - 1) - log_ratio)).cpu().numpy()
+                    approx_kl_div = th.mean((th.exp(log_ratio) - 1) - log_ratio).cpu().numpy()
                     approx_kl_divs.append(approx_kl_div)
 
                 if self.target_kl is not None and approx_kl_div > 1.5 * self.target_kl:

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -167,10 +167,12 @@ def test_device_buffer(replay_buffer_cls, device):
         obs = next_obs
 
     # Get data from the buffer
-    if replay_buffer_cls in [RolloutBuffer, DictRolloutBuffer, RecurrentRolloutBuffer]:
+    if replay_buffer_cls in [RolloutBuffer, DictRolloutBuffer]:
         data = buffer.get(50)
     elif replay_buffer_cls in [ReplayBuffer, DictReplayBuffer]:
         data = [buffer.sample(50)]
+    elif replay_buffer_cls == RecurrentRolloutBuffer:
+        data = buffer.get(EP_LENGTH)
 
     # Check that all data are on the desired device
     desired_device = get_device(device).type

--- a/tests/test_deterministic.py
+++ b/tests/test_deterministic.py
@@ -27,7 +27,7 @@ def test_deterministic_training_common(algo):
             kwargs.update({"n_steps": 64, "n_epochs": 4})
         elif algo == RecurrentPPO:
             kwargs.update({"policy_kwargs": dict(net_arch=[], enable_critic_lstm=True, lstm_hidden_size=8)})
-            kwargs.update({"n_steps": 50, "n_epochs": 4})
+            kwargs.update({"n_steps": 50, "n_epochs": 4, "batch_size": 100})
 
     policy_str = "MlpLstmPolicy" if algo == RecurrentPPO else "MlpPolicy"
     for i in range(2):

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -31,18 +31,18 @@ def test_discrete(model_class, env):
         if isinstance(env, (IdentityEnvMultiDiscrete, IdentityEnvMultiBinary)):
             return
     else:
-        CONCURRENT_ROLLOUT_STEPS = 32
+        CONCURRENT_ROLLOUT_STEPS = 16
         SEQUENTIAL_ROLLOUT_STEPS = 10
         env_ = DummyVecEnv([lambda: copy.deepcopy(env)] * CONCURRENT_ROLLOUT_STEPS)
-        kwargs = dict(n_steps=SEQUENTIAL_ROLLOUT_STEPS, learning_rate=2e-3)
+        kwargs = dict(n_steps=SEQUENTIAL_ROLLOUT_STEPS)
 
         if model_class in (PPO, RecurrentPPO):
             kwargs["batch_size"] = CONCURRENT_ROLLOUT_STEPS * SEQUENTIAL_ROLLOUT_STEPS
 
         if model_class == RecurrentPPO:
-            TOTAL_TIMESTEPS = 25000
+            TOTAL_TIMESTEPS = 35000
         else:
-            TOTAL_TIMESTEPS = 20000
+            TOTAL_TIMESTEPS = 30000
 
     model = model_class("MlpPolicy", env_, gamma=0.4, seed=3, **kwargs).learn(TOTAL_TIMESTEPS)
 

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -34,7 +34,7 @@ def test_discrete(model_class, env):
         CONCURRENT_ROLLOUT_STEPS = 16
         SEQUENTIAL_ROLLOUT_STEPS = 10
         env_ = DummyVecEnv([lambda: copy.deepcopy(env)] * CONCURRENT_ROLLOUT_STEPS)
-        kwargs = dict(n_steps=SEQUENTIAL_ROLLOUT_STEPS, learning_rate=1e-3)
+        kwargs = dict(n_steps=SEQUENTIAL_ROLLOUT_STEPS, learning_rate=7e-3)
 
         if model_class in (PPO, RecurrentPPO):
             kwargs["batch_size"] = CONCURRENT_ROLLOUT_STEPS * SEQUENTIAL_ROLLOUT_STEPS

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -2,6 +2,7 @@ import copy
 
 import numpy as np
 import pytest
+import torch
 
 from stable_baselines3 import A2C, DDPG, DQN, PPO, SAC, TD3, RecurrentPPO
 from stable_baselines3.common.envs import (
@@ -21,6 +22,7 @@ DIM = 4
 @pytest.mark.parametrize("model_class", [A2C, PPO, DQN, RecurrentPPO])
 @pytest.mark.parametrize("env", [IdentityEnv(DIM), IdentityEnvMultiDiscrete(DIM), IdentityEnvMultiBinary(DIM)])
 def test_discrete(model_class, env):
+    torch.manual_seed(1234)
     if model_class == DQN:
         TOTAL_TIMESTEPS = 10000
         env_ = DummyVecEnv([lambda: copy.deepcopy(env)])

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -34,7 +34,7 @@ def test_discrete(model_class, env):
         CONCURRENT_ROLLOUT_STEPS = 16
         SEQUENTIAL_ROLLOUT_STEPS = 10
         env_ = DummyVecEnv([lambda: copy.deepcopy(env)] * CONCURRENT_ROLLOUT_STEPS)
-        kwargs = dict(n_steps=SEQUENTIAL_ROLLOUT_STEPS)
+        kwargs = dict(n_steps=SEQUENTIAL_ROLLOUT_STEPS, learning_rate=1e-3)
 
         if model_class in (PPO, RecurrentPPO):
             kwargs["batch_size"] = CONCURRENT_ROLLOUT_STEPS * SEQUENTIAL_ROLLOUT_STEPS

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -21,7 +21,7 @@ DIM = 4
 def test_discrete(model_class, env):
     env_ = DummyVecEnv([lambda: env])
     kwargs = {}
-    n_steps = 25000 if model_class == RecurrentPPO else 10000
+    n_steps = 10000
     if model_class == DQN:
         kwargs = dict(learning_starts=0)
         # DQN only support discrete actions

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -29,9 +29,8 @@ def test_discrete(model_class, env):
         if isinstance(env, (IdentityEnvMultiDiscrete, IdentityEnvMultiBinary)):
             return
     else:
-        TOTAL_TIMESTEPS = 20000
         CONCURRENT_ROLLOUT_STEPS = 16
-        SEQUENTIAL_ROLLOUT_STEPS = 8
+        SEQUENTIAL_ROLLOUT_STEPS = 10
         env_ = DummyVecEnv([lambda: copy.deepcopy(env)] * CONCURRENT_ROLLOUT_STEPS)
         kwargs = dict(n_steps=SEQUENTIAL_ROLLOUT_STEPS)
 
@@ -40,6 +39,8 @@ def test_discrete(model_class, env):
 
         if model_class == RecurrentPPO:
             TOTAL_TIMESTEPS = 25000
+        else:
+            TOTAL_TIMESTEPS = 20000
 
     model = model_class("MlpPolicy", env_, gamma=0.4, seed=3, **kwargs).learn(TOTAL_TIMESTEPS)
 

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -31,7 +31,7 @@ def test_discrete(model_class, env):
         if isinstance(env, (IdentityEnvMultiDiscrete, IdentityEnvMultiBinary)):
             return
     else:
-        TOTAL_TIMESTEPS = 35000
+        TOTAL_TIMESTEPS = 50000
         CONCURRENT_ROLLOUT_STEPS = 32
         SEQUENTIAL_ROLLOUT_STEPS = 8
         env_ = DummyVecEnv([lambda: copy.deepcopy(env)] * CONCURRENT_ROLLOUT_STEPS)

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -21,7 +21,7 @@ DIM = 4
 def test_discrete(model_class, env):
     env_ = DummyVecEnv([lambda: env])
     kwargs = {}
-    n_steps = 10000
+    n_steps = 20000 if model_class == RecurrentPPO and isinstance(env, IdentityEnvMultiBinary) else 10000
     if model_class == DQN:
         kwargs = dict(learning_starts=0)
         # DQN only support discrete actions

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -31,10 +31,10 @@ def test_discrete(model_class, env):
         if isinstance(env, (IdentityEnvMultiDiscrete, IdentityEnvMultiBinary)):
             return
     else:
-        CONCURRENT_ROLLOUT_STEPS = 16
+        CONCURRENT_ROLLOUT_STEPS = 32
         SEQUENTIAL_ROLLOUT_STEPS = 10
         env_ = DummyVecEnv([lambda: copy.deepcopy(env)] * CONCURRENT_ROLLOUT_STEPS)
-        kwargs = dict(n_steps=SEQUENTIAL_ROLLOUT_STEPS, learning_rate=7e-3)
+        kwargs = dict(n_steps=SEQUENTIAL_ROLLOUT_STEPS, learning_rate=2e-3)
 
         if model_class in (PPO, RecurrentPPO):
             kwargs["batch_size"] = CONCURRENT_ROLLOUT_STEPS * SEQUENTIAL_ROLLOUT_STEPS

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -32,8 +32,8 @@ def test_discrete(model_class, env):
             return
     else:
         TOTAL_TIMESTEPS = 35000
-        CONCURRENT_ROLLOUT_STEPS = 16
-        SEQUENTIAL_ROLLOUT_STEPS = 10
+        CONCURRENT_ROLLOUT_STEPS = 32
+        SEQUENTIAL_ROLLOUT_STEPS = 8
         env_ = DummyVecEnv([lambda: copy.deepcopy(env)] * CONCURRENT_ROLLOUT_STEPS)
         kwargs = dict(n_steps=SEQUENTIAL_ROLLOUT_STEPS)
 

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -31,6 +31,7 @@ def test_discrete(model_class, env):
         if isinstance(env, (IdentityEnvMultiDiscrete, IdentityEnvMultiBinary)):
             return
     else:
+        TOTAL_TIMESTEPS = 35000
         CONCURRENT_ROLLOUT_STEPS = 16
         SEQUENTIAL_ROLLOUT_STEPS = 10
         env_ = DummyVecEnv([lambda: copy.deepcopy(env)] * CONCURRENT_ROLLOUT_STEPS)
@@ -38,11 +39,6 @@ def test_discrete(model_class, env):
 
         if model_class in (PPO, RecurrentPPO):
             kwargs["batch_size"] = CONCURRENT_ROLLOUT_STEPS * SEQUENTIAL_ROLLOUT_STEPS
-
-        if model_class == RecurrentPPO:
-            TOTAL_TIMESTEPS = 35000
-        else:
-            TOTAL_TIMESTEPS = 30000
 
     model = model_class("MlpPolicy", env_, gamma=0.4, seed=3, **kwargs).learn(TOTAL_TIMESTEPS)
 

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -38,6 +38,9 @@ def test_discrete(model_class, env):
         if model_class in (PPO, RecurrentPPO):
             kwargs["batch_size"] = CONCURRENT_ROLLOUT_STEPS * SEQUENTIAL_ROLLOUT_STEPS
 
+        if model_class == RecurrentPPO:
+            TOTAL_TIMESTEPS = 25000
+
     model = model_class("MlpPolicy", env_, gamma=0.4, seed=3, **kwargs).learn(TOTAL_TIMESTEPS)
 
     evaluate_policy(model, env_, n_eval_episodes=20, reward_threshold=99, warn=False)

--- a/tests/test_lstm.py
+++ b/tests/test_lstm.py
@@ -294,7 +294,7 @@ def test_ppo_lstm_performance(policy: str | type[BaseRecurrentActorCriticPolicy]
         ),
     )
 
-    model.learn(total_timesteps=60_000, callback=eval_callback)
+    model.learn(total_timesteps=100_000, callback=eval_callback)
     # Maximum episode reward is 500.
     # In CartPole-v1, a non-recurrent policy can easily get >= 450.
     # In CartPoleNoVelEnv, a non-recurrent policy doesn't get more than ~50.

--- a/tests/test_lstm.py
+++ b/tests/test_lstm.py
@@ -258,7 +258,9 @@ def test_ppo_lstm_performance(policy: str | type[BaseRecurrentActorCriticPolicy]
         env = TimeLimit(env, max_episode_steps=500)
         return env
 
-    env = VecNormalize(make_vec_env(make_env, n_envs=8))
+    N_ENVS = 16
+    N_STEPS = 32
+    env = VecNormalize(make_vec_env(make_env, n_envs=N_ENVS))
 
     eval_callback = EvalCallback(
         VecNormalize(make_vec_env(make_env, n_envs=4), training=False, norm_reward=False),
@@ -277,10 +279,10 @@ def test_ppo_lstm_performance(policy: str | type[BaseRecurrentActorCriticPolicy]
     model = RecurrentPPO(
         policy,
         env,
-        n_steps=128,
+        n_steps=N_STEPS,
         learning_rate=0.0007,
         verbose=1,
-        batch_size=256,
+        batch_size=N_ENVS * N_STEPS,
         seed=1,
         n_epochs=10,
         max_grad_norm=1,
@@ -292,7 +294,7 @@ def test_ppo_lstm_performance(policy: str | type[BaseRecurrentActorCriticPolicy]
         ),
     )
 
-    model.learn(total_timesteps=50_000, callback=eval_callback)
+    model.learn(total_timesteps=60_000, callback=eval_callback)
     # Maximum episode reward is 500.
     # In CartPole-v1, a non-recurrent policy can easily get >= 450.
     # In CartPoleNoVelEnv, a non-recurrent policy doesn't get more than ~50.

--- a/tests/test_vec_envs.py
+++ b/tests/test_vec_envs.py
@@ -602,3 +602,21 @@ def test_render(vec_env_class):
     vec_env.render()
 
     vec_env.close()
+
+
+@pytest.mark.parametrize("vec_env_class", VEC_ENV_CLASSES)
+# n_envs: pick something that can fit in a rectangle, and something that cannot.
+@pytest.mark.parametrize("n_envs", [2, 3])
+def test_render_rgb(vec_env_class, n_envs: int):
+    """Test that we can tile_images on a vec_env with a non-rectangular number of envs."""
+    env_id = "Pendulum-v1"
+    vec_env = make_vec_env(
+        env_id,
+        n_envs,
+        vec_env_cls=vec_env_class,
+        env_kwargs=dict(render_mode="rgb_array"),
+    )
+    vec_env.reset()
+    out = vec_env.render()
+    assert out.ndim == 3, "There should be no batch dimension"
+    assert out.shape[-1] == 3, "Image is not HWC"

--- a/tests/test_vec_envs.py
+++ b/tests/test_vec_envs.py
@@ -14,7 +14,12 @@ from gymnasium import spaces
 
 from stable_baselines3.common.env_util import make_vec_env
 from stable_baselines3.common.monitor import Monitor
-from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv, VecFrameStack, VecNormalize
+from stable_baselines3.common.vec_env import (
+    DummyVecEnv,
+    SubprocVecEnv,
+    VecFrameStack,
+    VecNormalize,
+)
 
 N_ENVS = 3
 VEC_ENV_CLASSES = [DummyVecEnv, SubprocVecEnv]

--- a/tests/test_vec_envs.py
+++ b/tests/test_vec_envs.py
@@ -14,6 +14,7 @@ from gymnasium import spaces
 
 from stable_baselines3.common.env_util import make_vec_env
 from stable_baselines3.common.monitor import Monitor
+from stable_baselines3.common.type_aliases import non_null
 from stable_baselines3.common.vec_env import (
     DummyVecEnv,
     SubprocVecEnv,
@@ -617,6 +618,6 @@ def test_render_rgb(vec_env_class, n_envs: int):
         env_kwargs=dict(render_mode="rgb_array"),
     )
     vec_env.reset()
-    out = vec_env.render()
+    out = non_null(vec_env.render())
     assert out.ndim == 3, "There should be no batch dimension"
     assert out.shape[-1] == 3, "Image is not HWC"


### PR DESCRIPTION
A large amount of runtime was spent doing tensor copies related to the recurrent buffer, mostly due to the flatten-and-swapaxes maneuver. This PR removes that.

- update `common/distributions.py` to accept distribution parameter tensors that have more than 2 dimensions.
- Make sure `current_rewards` and `rewards` are in the same device in `common/evaluation.py`
- Make the policy's Optimizer a property so it gets created after the policy gets moved to CUDA
  - this lets us use the fused implementation for Adam
- In `recurrent/buffers.py`: remove all the sequence padding stuff, and just take sequences from the RecurrentBuffer and return them.
  - the problem here is that now sometimes `episode_starts` will be True at a place other than the initial time step. Thus we have to adjust `recurrent/torch_layers.py` to allow for this.
  - as a result of this, we don't need a `RecurrentRolloutBufferSamples.mask` anymore
- fix bug in `tile_images` and test it 