### PR TITLE
add `think_for_n_steps` in recurrent models

### DIFF
--- a/stable_baselines3/common/base_class.py
+++ b/stable_baselines3/common/base_class.py
@@ -133,6 +133,8 @@ class BaseAlgorithm(ABC):
     n_envs: int
     lr_schedule: Schedule
     _logger: Logger
+    _last_obs: Optional[TorchGymObsBasic]
+    _last_episode_starts: Optional[th.Tensor]
 
     def __init__(
         self,

--- a/stable_baselines3/common/callbacks.py
+++ b/stable_baselines3/common/callbacks.py
@@ -1,7 +1,7 @@
 import os
 import warnings
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import gymnasium as gym
 import numpy as np
@@ -21,7 +21,11 @@ except ImportError:
 
 from stable_baselines3.common import base_class  # pytype: disable=pyi-error
 from stable_baselines3.common.evaluation import evaluate_policy
-from stable_baselines3.common.vec_env import DummyVecEnv, VecEnv, sync_envs_normalization
+from stable_baselines3.common.vec_env import (
+    DummyVecEnv,
+    VecEnv,
+    sync_envs_normalization,
+)
 
 
 class BaseCallback(ABC):
@@ -436,6 +440,18 @@ class EvalCallback(EventCallback):
             if maybe_is_success is not None:
                 self._is_success_buffer.append(maybe_is_success)
 
+    def _evaluate_policy(self) -> Union[Tuple[float, float], Tuple[List[float], List[int]]]:
+        return evaluate_policy(
+            self.model,
+            self.eval_env,
+            n_eval_episodes=self.n_eval_episodes,
+            render=self.render,
+            deterministic=self.deterministic,
+            return_episode_rewards=True,
+            warn=self.warn,
+            callback=self._log_success_callback,
+        )
+
     def _on_step(self) -> bool:
         continue_training = True
 
@@ -453,17 +469,7 @@ class EvalCallback(EventCallback):
 
             # Reset success rate buffer
             self._is_success_buffer = []
-
-            episode_rewards, episode_lengths = evaluate_policy(
-                self.model,
-                self.eval_env,
-                n_eval_episodes=self.n_eval_episodes,
-                render=self.render,
-                deterministic=self.deterministic,
-                return_episode_rewards=True,
-                warn=self.warn,
-                callback=self._log_success_callback,
-            )
+            episode_rewards, episode_lengths = self._evaluate_policy()
 
             if self.log_path is not None:
                 assert isinstance(episode_rewards, list)

--- a/stable_baselines3/common/callbacks.py
+++ b/stable_baselines3/common/callbacks.py
@@ -442,8 +442,8 @@ class EvalCallback(EventCallback):
 
     def _evaluate_policy(
         self,
-    ) -> Union[Tuple[float, float], Tuple[List[float], List[int]]]:  # pytype: disable=bad-return-type
-        return evaluate_policy(
+    ) -> Union[Tuple[float, float], Tuple[List[float], List[int]]]:
+        return evaluate_policy(  # pytype: disable=bad-return-type
             self.model,
             self.eval_env,
             n_eval_episodes=self.n_eval_episodes,

--- a/stable_baselines3/common/callbacks.py
+++ b/stable_baselines3/common/callbacks.py
@@ -440,7 +440,9 @@ class EvalCallback(EventCallback):
             if maybe_is_success is not None:
                 self._is_success_buffer.append(maybe_is_success)
 
-    def _evaluate_policy(self) -> Union[Tuple[float, float], Tuple[List[float], List[int]]]:
+    def _evaluate_policy(
+        self,
+    ) -> Union[Tuple[float, float], Tuple[List[float], List[int]]]:  # pytype: disable=bad-return-type
         return evaluate_policy(
             self.model,
             self.eval_env,

--- a/stable_baselines3/common/evaluation.py
+++ b/stable_baselines3/common/evaluation.py
@@ -102,6 +102,9 @@ def evaluate_policy(
         with th.no_grad():
             if hasattr(model, "think_for_n_steps"):
                 states = model.think_for_n_steps(n_steps_to_think, observations, states, episode_starts)
+            else:
+                if n_steps_to_think > 0:
+                    raise TypeError(f"Policy {model} cannot think for longer than 0 steps.")
             actions, states = model.predict(
                 observations,  # type: ignore[arg-type]
                 state=states,

--- a/stable_baselines3/common/evaluation.py
+++ b/stable_baselines3/common/evaluation.py
@@ -4,14 +4,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import gymnasium as gym
 import numpy as np
 import torch as th
-
 from stable_baselines3.common import type_aliases
-from stable_baselines3.common.vec_env import (
-    DummyVecEnv,
-    VecEnv,
-    VecMonitor,
-    is_vecenv_wrapped,
-)
+from stable_baselines3.common.vec_env import DummyVecEnv, VecEnv, VecMonitor, is_vecenv_wrapped
 from stable_baselines3.common.vec_env.util import obs_as_tensor
 
 
@@ -98,6 +92,8 @@ def evaluate_policy(
     episode_starts = th.ones((env.num_envs,), dtype=th.bool, device=model.device)
     while (episode_counts < episode_count_targets).any():
         with th.no_grad():
+            if model.steps_to_think > 0:
+                states = model.think_for_n_steps(observations, states, episode_starts)
             actions, states = model.predict(
                 observations,  # type: ignore[arg-type]
                 state=states,

--- a/stable_baselines3/common/evaluation.py
+++ b/stable_baselines3/common/evaluation.py
@@ -4,8 +4,14 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import gymnasium as gym
 import numpy as np
 import torch as th
+
 from stable_baselines3.common import type_aliases
-from stable_baselines3.common.vec_env import DummyVecEnv, VecEnv, VecMonitor, is_vecenv_wrapped
+from stable_baselines3.common.vec_env import (
+    DummyVecEnv,
+    VecEnv,
+    VecMonitor,
+    is_vecenv_wrapped,
+)
 from stable_baselines3.common.vec_env.util import obs_as_tensor
 
 
@@ -19,6 +25,7 @@ def evaluate_policy(
     reward_threshold: Optional[float] = None,
     return_episode_rewards: bool = False,
     warn: bool = True,
+    steps_to_think: Optional[int] = None,
 ) -> Union[Tuple[float, float], Tuple[List[float], List[int]]]:
     """
     Runs policy for ``n_eval_episodes`` episodes and returns average reward.
@@ -50,6 +57,8 @@ def evaluate_policy(
         per episode will be returned instead of the mean.
     :param warn: If True (default), warns user about lack of a Monitor wrapper in the
         evaluation environment.
+    :param steps_to_think: how many steps should the model think before taking the first action? If None, copy the
+        default from `model`.
     :return: Mean reward per episode, std of reward per episode.
         Returns ([float], [int]) when ``return_episode_rewards`` is True, first
         list containing per-episode rewards and second containing per-episode lengths
@@ -79,6 +88,10 @@ def evaluate_policy(
     observations = env.reset()
     observations = obs_as_tensor(observations, model.device)
 
+    if steps_to_think is None:
+        steps_to_think = getattr(model, "steps_to_think", 0)
+    assert steps_to_think is not None
+
     # Hardcode episode counts and the reward accumulators to use CPU. They're used for bookkeeping and don't involve
     # much computation.
 
@@ -92,8 +105,8 @@ def evaluate_policy(
     episode_starts = th.ones((env.num_envs,), dtype=th.bool, device=model.device)
     while (episode_counts < episode_count_targets).any():
         with th.no_grad():
-            if model.steps_to_think > 0:
-                states = model.think_for_n_steps(observations, states, episode_starts)
+            if hasattr(model, "think_for_n_steps"):
+                states = model.think_for_n_steps(steps_to_think, observations, states, episode_starts)
             actions, states = model.predict(
                 observations,  # type: ignore[arg-type]
                 state=states,

--- a/stable_baselines3/common/on_policy_algorithm.py
+++ b/stable_baselines3/common/on_policy_algorithm.py
@@ -9,7 +9,11 @@ from stable_baselines3.common.base_class import BaseAlgorithm
 from stable_baselines3.common.buffers import DictRolloutBuffer, RolloutBuffer
 from stable_baselines3.common.callbacks import BaseCallback
 from stable_baselines3.common.policies import ActorCriticPolicy
-from stable_baselines3.common.type_aliases import GymEnv, MaybeCallback, Schedule
+from stable_baselines3.common.type_aliases import (
+    GymEnv,
+    MaybeCallback,
+    Schedule,
+)
 from stable_baselines3.common.utils import safe_mean
 from stable_baselines3.common.vec_env import VecEnv
 from stable_baselines3.common.vec_env.util import obs_as_tensor

--- a/stable_baselines3/common/recurrent/policies.py
+++ b/stable_baselines3/common/recurrent/policies.py
@@ -12,7 +12,6 @@ from stable_baselines3.common.policies import ActorCriticPolicy
 from stable_baselines3.common.preprocessing import preprocess_obs
 from stable_baselines3.common.pytree_dataclass import tree_flatten
 from stable_baselines3.common.recurrent.torch_layers import (
-    ExtractorInput,
     GRUNatureCNNExtractor,
     GRUWrappedFeaturesExtractor,
     LSTMFlattenExtractor,
@@ -189,7 +188,7 @@ class BaseRecurrentActorCriticPolicy(ActorCriticPolicy, Generic[RecurrentState])
         return actions, state
 
 
-class RecurrentActorCriticPolicy(BaseRecurrentActorCriticPolicy):
+class RecurrentActorCriticPolicy(BaseRecurrentActorCriticPolicy[ActorCriticStates[LSTMRecurrentState]]):
     """
     Recurrent policy class for actor-critic algorithms (has both policy and value prediction).
     To be used with A2C, PPO and the likes.
@@ -328,7 +327,9 @@ class RecurrentActorCriticPolicy(BaseRecurrentActorCriticPolicy):
             device=self.device,
         )
 
-    def recurrent_initial_state(self, n_envs: Optional[int] = None, *, device: Optional[th.device | str] = None):
+    def recurrent_initial_state(
+        self, n_envs: Optional[int] = None, *, device: Optional[th.device | str] = None
+    ) -> ActorCriticStates[LSTMRecurrentState]:
         shape: tuple[int, ...]
         if n_envs is None:
             shape = (self.lstm_hidden_state_shape[0], self.lstm_hidden_state_shape[2])
@@ -628,8 +629,8 @@ class RecurrentMultiInputActorCriticPolicy(RecurrentActorCriticPolicy):
         )
 
 
-class RecurrentFeaturesExtractorActorCriticPolicy(BaseRecurrentActorCriticPolicy, Generic[ExtractorInput, RecurrentState]):
-    features_extractor: RecurrentFeaturesExtractor[ExtractorInput, RecurrentState]
+class RecurrentFeaturesExtractorActorCriticPolicy(BaseRecurrentActorCriticPolicy[RecurrentState], Generic[RecurrentState]):
+    features_extractor: RecurrentFeaturesExtractor[TorchGymObs, RecurrentState]
 
     def __init__(
         self,

--- a/stable_baselines3/ppo_recurrent/ppo_recurrent.py
+++ b/stable_baselines3/ppo_recurrent/ppo_recurrent.py
@@ -13,13 +13,9 @@ from stable_baselines3.common.on_policy_algorithm import OnPolicyAlgorithm
 from stable_baselines3.common.policies import BasePolicy
 from stable_baselines3.common.pytree_dataclass import tree_index, tree_map
 from stable_baselines3.common.recurrent.buffers import RecurrentRolloutBuffer
-from stable_baselines3.common.recurrent.policies import (
-    BaseRecurrentActorCriticPolicy,
-)
+from stable_baselines3.common.recurrent.policies import BaseRecurrentActorCriticPolicy
 from stable_baselines3.common.recurrent.torch_layers import RecurrentState
-from stable_baselines3.common.recurrent.type_aliases import (
-    RecurrentRolloutBufferData,
-)
+from stable_baselines3.common.recurrent.type_aliases import RecurrentRolloutBufferData
 from stable_baselines3.common.type_aliases import (
     GymEnv,
     MaybeCallback,
@@ -86,7 +82,6 @@ class RecurrentPPO(OnPolicyAlgorithm, Generic[RecurrentState]):
     :param device: Device (cpu, cuda, ...) on which the code should be run.
         Setting it to auto, the code will be run on the GPU if possible.
     :param _init_setup_model: Whether or not to build the network at the creation of the instance
-    :param steps_to_think: The number of extra policy steps (forward passes) to perform at the start of the episode.
     """
 
     policy_aliases: ClassVar[Dict[str, Type[BasePolicy]]] = {
@@ -129,7 +124,6 @@ class RecurrentPPO(OnPolicyAlgorithm, Generic[RecurrentState]):
         seed: Optional[int] = None,
         device: Union[th.device, str] = "auto",
         _init_setup_model: bool = True,
-        steps_to_think: int = 0,
     ):
         super().__init__(
             policy,
@@ -204,7 +198,6 @@ class RecurrentPPO(OnPolicyAlgorithm, Generic[RecurrentState]):
         self.normalize_advantage = normalize_advantage
         self.target_kl = target_kl
         self._last_lstm_states: Optional[RecurrentState] = None
-        self.steps_to_think = steps_to_think
 
         if _init_setup_model:
             self._setup_model()
@@ -316,7 +309,6 @@ class RecurrentPPO(OnPolicyAlgorithm, Generic[RecurrentState]):
                 # Convert to pytorch tensor or to TensorDict
                 obs_tensor = obs_as_tensor(self._last_obs, self.device)
                 episode_starts = non_null(self._last_episode_starts)
-                lstm_states = self.think_for_n_steps(self.steps_to_think, obs_tensor, lstm_states, episode_starts)
                 actions, values, log_probs, lstm_states = self.policy.forward(obs_tensor, lstm_states, episode_starts)
 
             # Rescale and perform action

--- a/stable_baselines3/ppo_recurrent/ppo_recurrent.py
+++ b/stable_baselines3/ppo_recurrent/ppo_recurrent.py
@@ -213,7 +213,7 @@ class RecurrentPPO(OnPolicyAlgorithm, Generic[RecurrentState]):
             return lstm_states
         # ignore because TorchGymObs and TensorTree do not match
         obs_for_start_envs: TorchGymObs = tree_index(obs_tensor, (episode_starts,))  # type: ignore[type-var]
-        lstm_states_for_start_envs = tree_index(lstm_states, (episode_starts,))
+        lstm_states_for_start_envs = tree_index(lstm_states, (slice(None), episode_starts))
         for _ in range(n_steps):
             _, _, _, lstm_states_for_start_envs = self.policy.forward(
                 obs_for_start_envs,

--- a/tests/test_lstm.py
+++ b/tests/test_lstm.py
@@ -236,10 +236,12 @@ def test_run_sde_recurrent_extractor():
         ),
     ],
 )
-def test_dict_obs(policy_kwargs):
-    env = make_vec_env("CartPole-v1", n_envs=1, wrapper_class=ToDictWrapper)
+@pytest.mark.parametrize("n_steps_to_think", [0, 1, 4])
+def test_dict_obs(policy_kwargs, n_steps_to_think):
+    N_ENVS = 10
+    env = make_vec_env("CartPole-v1", n_envs=N_ENVS, wrapper_class=ToDictWrapper)
     model = RecurrentPPO("MultiInputLstmPolicy", env, n_steps=32, policy_kwargs=policy_kwargs).learn(64)
-    evaluate_policy(model, env, warn=False)
+    evaluate_policy(model, env, n_eval_episodes=N_ENVS, warn=False, n_steps_to_think=n_steps_to_think)
 
 
 def test_dict_obs_recurrent_extractor():


### PR DESCRIPTION
Recurrent models can now think for n steps (i.e. evaluate the same set of initial observations N times), for some environments only. This is used in `evaluate_policy` to think for N steps before acting.

Possibly an inefficient implementation and we should just pad episodes to the full `max_episode_steps`, and only do thinking for all environments at once. But I think it's good enough for now -- testing isn't that expensive.