### PR TITLE
Coefficient schedule & logs for value clipping

### DIFF
--- a/stable_baselines3/common/on_policy_algorithm.py
+++ b/stable_baselines3/common/on_policy_algorithm.py
@@ -9,12 +9,8 @@ from stable_baselines3.common.base_class import BaseAlgorithm
 from stable_baselines3.common.buffers import DictRolloutBuffer, RolloutBuffer
 from stable_baselines3.common.callbacks import BaseCallback
 from stable_baselines3.common.policies import ActorCriticPolicy
-from stable_baselines3.common.type_aliases import (
-    GymEnv,
-    MaybeCallback,
-    Schedule,
-)
-from stable_baselines3.common.utils import safe_mean
+from stable_baselines3.common.type_aliases import GymEnv, MaybeCallback, Schedule
+from stable_baselines3.common.utils import get_schedule_fn, safe_mean
 from stable_baselines3.common.vec_env import VecEnv
 from stable_baselines3.common.vec_env.util import obs_as_tensor
 
@@ -59,6 +55,8 @@ class OnPolicyAlgorithm(BaseAlgorithm):
     rollout_buffer: RolloutBuffer
     policy: ActorCriticPolicy
     policy_class: Type[ActorCriticPolicy]
+    ent_coef: Schedule
+    vf_coef: Schedule
 
     def __init__(
         self,
@@ -68,8 +66,8 @@ class OnPolicyAlgorithm(BaseAlgorithm):
         n_steps: int,
         gamma: float,
         gae_lambda: float,
-        ent_coef: float,
-        vf_coef: float,
+        ent_coef: Union[float, Schedule],
+        vf_coef: Union[float, Schedule],
         max_grad_norm: Optional[float],
         use_sde: bool,
         sde_sample_freq: int,
@@ -102,8 +100,8 @@ class OnPolicyAlgorithm(BaseAlgorithm):
         self.n_steps = n_steps
         self.gamma = gamma
         self.gae_lambda = gae_lambda
-        self.ent_coef = ent_coef
-        self.vf_coef = vf_coef
+        self.ent_coef = get_schedule_fn(ent_coef)
+        self.vf_coef = get_schedule_fn(vf_coef)
         self.max_grad_norm = max_grad_norm
 
         if _init_setup_model:

--- a/stable_baselines3/common/utils.py
+++ b/stable_baselines3/common/utils.py
@@ -94,7 +94,7 @@ def update_learning_rate(optimizer: th.optim.Optimizer, learning_rate: float) ->
         param_group["lr"] = learning_rate
 
 
-def get_schedule_fn(value_schedule: Union[Schedule, float]) -> Schedule:
+def get_schedule_fn(value_schedule: Union[Schedule, float, int]) -> Schedule:
     """
     Transform (if needed) learning rate and clip range (for PPO)
     to callable.

--- a/stable_baselines3/ppo/ppo.py
+++ b/stable_baselines3/ppo/ppo.py
@@ -188,6 +188,9 @@ class PPO(OnPolicyAlgorithm):
         # Optional: clip range for the value function
         clip_range_vf = None if self.clip_range_vf is None else self.clip_range_vf(self._current_progress_remaining)  # type: ignore[operator]
 
+        ent_coef: float = self.ent_coef(self._current_progress_remaining)
+        vf_coef: float = self.vf_coef(self._current_progress_remaining)
+
         entropy_losses = []
         pg_losses, value_losses = [], []
         clip_fractions = []
@@ -262,7 +265,7 @@ class PPO(OnPolicyAlgorithm):
 
                 entropy_losses.append(entropy_loss.item())
 
-                loss = policy_loss + self.ent_coef * entropy_loss + self.vf_coef * value_loss
+                loss = policy_loss + ent_coef * entropy_loss + vf_coef * value_loss
 
                 # Calculate approximate form of reverse KL Divergence for early stopping
                 # see issue #417: https://github.com/DLR-RM/stable-baselines3/issues/417
@@ -309,7 +312,7 @@ class PPO(OnPolicyAlgorithm):
 
         self.logger.record("train/n_updates", self._n_updates, exclude="tensorboard")
         self.logger.record("train/clip_range", clip_range)
-        if self.clip_range_vf is not None:
+        if clip_range_vf is not None:
             self.logger.record("train/clip_range_vf", clip_range_vf)
 
     def learn(

--- a/stable_baselines3/ppo/ppo.py
+++ b/stable_baselines3/ppo/ppo.py
@@ -253,8 +253,9 @@ class PPO(OnPolicyAlgorithm):
                     value_diffs_mean.append(value_diff_abs.mean().item())
                     value_diffs_min.append(value_diff_abs.min().item())
                     value_diffs_max.append(value_diff_abs.max().item())
-                    clip_fraction_vf = th.mean((value_diff_abs > clip_range_vf).float()).item()
-                clip_fractions_vf.append(clip_fraction_vf)
+                    if clip_range_vf is not None:
+                        clip_fraction_vf = th.mean((value_diff_abs > clip_range_vf).float()).item()
+                        clip_fractions_vf.append(clip_fraction_vf)
 
                 # Entropy loss favor exploration
                 if entropy is None:
@@ -304,7 +305,6 @@ class PPO(OnPolicyAlgorithm):
         self.logger.record("train/value_diff_max", np.max(value_diffs_max))
         self.logger.record("train/approx_kl", approx_kl_div)
         self.logger.record("train/clip_fraction", np.mean(clip_fractions))
-        self.logger.record("train/clip_fraction_vf", np.mean(clip_fractions_vf))
         self.logger.record("train/loss", loss.item())
         self.logger.record("train/explained_variance", explained_var.item())
         if hasattr(self.policy, "log_std"):
@@ -314,6 +314,7 @@ class PPO(OnPolicyAlgorithm):
         self.logger.record("train/clip_range", clip_range)
         if clip_range_vf is not None:
             self.logger.record("train/clip_range_vf", clip_range_vf)
+            self.logger.record("train/clip_fraction_vf", np.mean(clip_fractions_vf))
 
     def learn(
         self: SelfPPO,

--- a/stable_baselines3/ppo_recurrent/ppo_recurrent.py
+++ b/stable_baselines3/ppo_recurrent/ppo_recurrent.py
@@ -476,8 +476,9 @@ class RecurrentPPO(OnPolicyAlgorithm, Generic[RecurrentState]):
                     value_diffs_mean.append(value_diff_abs.mean().item())
                     value_diffs_min.append(value_diff_abs.min().item())
                     value_diffs_max.append(value_diff_abs.max().item())
-                    clip_fraction_vf = th.mean((value_diff_abs > clip_range_vf).float()).item()
-                clip_fractions_vf.append(clip_fraction_vf)
+                    if clip_range_vf is not None:
+                        clip_fraction_vf = th.mean((value_diff_abs > clip_range_vf).float()).item()
+                        clip_fractions_vf.append(clip_fraction_vf)
 
                 # Entropy loss favor exploration
                 if entropy is None:
@@ -527,7 +528,6 @@ class RecurrentPPO(OnPolicyAlgorithm, Generic[RecurrentState]):
         self.logger.record("train/value_diff_max", np.max(value_diffs_max))
         self.logger.record("train/approx_kl", approx_kl_div)
         self.logger.record("train/clip_fraction", np.mean(clip_fractions))
-        self.logger.record("train/clip_fraction_vf", np.mean(clip_fractions_vf))
         self.logger.record("train/loss", loss.item())
         self.logger.record("train/explained_variance", explained_var.item())
         if hasattr(self.policy, "log_std"):
@@ -537,6 +537,7 @@ class RecurrentPPO(OnPolicyAlgorithm, Generic[RecurrentState]):
         self.logger.record("train/clip_range", clip_range)
         if clip_range_vf is not None:
             self.logger.record("train/clip_range_vf", clip_range_vf)
+            self.logger.record("train/clip_fraction_vf", np.mean(clip_fractions_vf))
 
     def learn(
         self: SelfRecurrentPPO,

--- a/stable_baselines3/ppo_recurrent/ppo_recurrent.py
+++ b/stable_baselines3/ppo_recurrent/ppo_recurrent.py
@@ -535,7 +535,7 @@ class RecurrentPPO(OnPolicyAlgorithm, Generic[RecurrentState]):
 
         self.logger.record("train/n_updates", self._n_updates, exclude="tensorboard")
         self.logger.record("train/clip_range", clip_range)
-        if self.clip_range_vf is not None:
+        if clip_range_vf is not None:
             self.logger.record("train/clip_range_vf", clip_range_vf)
 
     def learn(

--- a/stable_baselines3/ppo_recurrent/ppo_recurrent.py
+++ b/stable_baselines3/ppo_recurrent/ppo_recurrent.py
@@ -409,6 +409,9 @@ class RecurrentPPO(OnPolicyAlgorithm, Generic[RecurrentState]):
 
         entropy_losses = []
         pg_losses, value_losses = [], []
+        value_diffs_mean = []
+        value_diffs_min = []
+        value_diffs_max = []
         clip_fractions = []
         approx_kl_divs = []
 
@@ -453,18 +456,22 @@ class RecurrentPPO(OnPolicyAlgorithm, Generic[RecurrentState]):
                     clip_fraction = th.mean((th.abs(ratio - 1) > clip_range).float()).item()
                 clip_fractions.append(clip_fraction)
 
+                value_diff = values - rollout_data.old_values
                 if self.clip_range_vf is None:
                     # No clipping
                     values_pred = values
                 else:
                     # Clip the difference between old and new value
                     # NOTE: this depends on the reward scaling
-                    values_pred = rollout_data.old_values + th.clamp(
-                        values - rollout_data.old_values, -clip_range_vf, clip_range_vf
-                    )
+                    values_pred = rollout_data.old_values + th.clamp(value_diff, -clip_range_vf, clip_range_vf)
                 # Value loss using the TD(gae_lambda) target
                 value_loss = F.mse_loss(rollout_data.returns, values_pred)
                 value_losses.append(value_loss.item())
+                with th.no_grad():
+                    value_diff_abs = value_diff.abs()
+                    value_diffs_mean.append(value_diff_abs.mean().item())
+                    value_diffs_min.append(value_diff_abs.min().item())
+                    value_diffs_max.append(value_diff_abs.max().item())
 
                 # Entropy loss favor exploration
                 if entropy is None:
@@ -510,6 +517,9 @@ class RecurrentPPO(OnPolicyAlgorithm, Generic[RecurrentState]):
         self.logger.record("train/entropy_loss", np.mean(entropy_losses))
         self.logger.record("train/policy_gradient_loss", np.mean(pg_losses))
         self.logger.record("train/value_loss", np.mean(value_losses))
+        self.logger.record("train/value_diff_mean", np.mean(value_diffs_mean))
+        self.logger.record("train/value_diff_min", np.min(value_diffs_min))
+        self.logger.record("train/value_diff_max", np.max(value_diffs_max))
         self.logger.record("train/approx_kl", np.mean(approx_kl_divs))
         self.logger.record("train/clip_fraction", np.mean(clip_fractions))
         self.logger.record("train/loss", loss.item())

--- a/stable_baselines3/ppo_recurrent/ppo_recurrent.py
+++ b/stable_baselines3/ppo_recurrent/ppo_recurrent.py
@@ -264,8 +264,8 @@ class RecurrentPPO(OnPolicyAlgorithm, Generic[RecurrentState]):
         self._last_lstm_states = tree_map(lambda x: th.zeros_like(x, memory_format=th.contiguous_format), hidden_state_example)
 
         # Initialize schedules for policy/value clipping and loss coefficients
-        self.ent_coef = get_schedule_fn(self.ent_coef)
-        self.vf_coef = get_schedule_fn(self.vf_coef)
+        self.ent_coef = get_schedule_fn(self.ent_coef)  # type: ignore[assignment]
+        self.vf_coef = get_schedule_fn(self.vf_coef)  # type: ignore[assignment]
         self.clip_range = get_schedule_fn(self.clip_range)
         if self.clip_range_vf is not None:
             if isinstance(self.clip_range_vf, (float, int)):
@@ -412,8 +412,8 @@ class RecurrentPPO(OnPolicyAlgorithm, Generic[RecurrentState]):
         else:
             clip_range_vf = math.inf
 
-        ent_coef = self.ent_coef(self._current_progress_remaining)
-        vf_coef = self.vf_coef(self._current_progress_remaining)
+        ent_coef: float = self.ent_coef(self._current_progress_remaining)  # type: ignore
+        vf_coef: float = self.vf_coef(self._current_progress_remaining)  # type: ignore
 
         entropy_losses = []
         pg_losses, value_losses = [], []


### PR DESCRIPTION
- Allow the `vf_coef` and `ent_coef` parameters in PPO and RecurrentPPO to be Schedules
- Constrain typing for the other formerly `float | Schedule` attributes (clip_range, clip_range_vf)
- Record max, min and average value estimate prior to clipping
- Record the KL div of the policy only at the *end* of optimization and not throughout (for both PPO (it was already like this there) and RecurrentPPO)