### PR TITLE
Extra rollout scrambling

### DIFF
--- a/stable_baselines3/common/recurrent/buffers.py
+++ b/stable_baselines3/common/recurrent/buffers.py
@@ -230,17 +230,18 @@ class RecurrentRolloutBuffer(RolloutBuffer):
 
             for i in range(0, len(batch_indices), batch_envs):
                 (first_time_idx, first_env_idx), idx = dset.get_batch_and_init_times(batch_indices[i : i + batch_envs])
+                idx_fn = functools.partial(_index_first_shape, idx)
                 yield RecurrentRolloutBufferSamples(
-                    observations=tree_map(functools.partial(_index_first_shape, idx), self.data.observations),
-                    actions=self.data.actions.view(-1)[idx],
-                    old_values=self.data.values.view(-1)[idx],
-                    old_log_prob=self.data.log_probs.view(-1)[idx],
-                    advantages=self.advantages.view(-1)[idx],
-                    returns=self.returns.view(-1)[idx],
+                    observations=tree_map(idx_fn, self.data.observations),
+                    actions=idx_fn(self.data.actions),
+                    old_values=idx_fn(self.data.values),
+                    old_log_prob=idx_fn(self.data.log_probs),
+                    advantages=idx_fn(self.advantages),
+                    returns=idx_fn(self.returns),
                     hidden_states=tree_map(
                         functools.partial(_index_first_time, first_time_idx, first_env_idx), self.data.hidden_states
                     ),
-                    episode_starts=self.data.episode_starts.view(-1)[idx],
+                    episode_starts=idx_fn(self.data.episode_starts),
                 )
 
     def _get_samples(  # type: ignore[override]

--- a/stable_baselines3/common/recurrent/buffers.py
+++ b/stable_baselines3/common/recurrent/buffers.py
@@ -1,4 +1,6 @@
 import dataclasses
+import enum
+import functools
 import logging
 from typing import Generator, Optional, Tuple, Union
 
@@ -39,8 +41,8 @@ def space_to_example(
     return tree_map(_zeros_with_batch, space.sample())
 
 
-class TimeContiguousBatchesDataset(th.utils.data.Dataset[th.Tensor]):
-    def __init__(self, num_envs: int, num_time: int, batch_time: int, skew: th.Tensor):
+class TimeContiguousBatchesDataset:
+    def __init__(self, num_envs: int, num_time: int, batch_time: int, skew: th.Tensor, device: th.device):
         assert batch_time > 0 and num_envs > 0 and num_time > 0
         assert num_time >= batch_time
         assert num_time % batch_time == 0
@@ -51,24 +53,32 @@ class TimeContiguousBatchesDataset(th.utils.data.Dataset[th.Tensor]):
         self.num_time = num_time
         self.batch_time = batch_time
         self.skew = skew
-        self.total_size = self.num_envs * self.num_time
+
+        self._arange_time = th.arange(self.batch_time, device=device).unsqueeze(1)
 
     def __getitem__(self, index: int) -> th.Tensor:
         which_env = index % self.num_envs
         which_time_batch = (index // self.num_envs) * self.batch_time
         skew = self.skew[which_env]
-        return which_env + self.num_envs * ((which_time_batch + skew + th.arange(self.batch_time)) % self.num_time)
+        return which_env + self.num_envs * ((which_time_batch + skew + self._arange_time.squeeze(1)) % self.num_time)
 
-    def __getitems__(self, indices: th.Tensor) -> th.Tensor:
+    def get_batch_and_init_times(self, indices: th.Tensor) -> tuple[tuple[th.Tensor, th.Tensor], th.Tensor]:
         which_env = indices % self.num_envs
         which_time_batch = (indices // self.num_envs) * self.batch_time
         skew = self.skew[which_env]
-        return which_env.unsqueeze(1) + self.num_envs * (
-            ((which_time_batch + skew).unsqueeze(1) + th.arange(self.batch_time)) % self.num_time
-        )
+
+        overall_idx = which_env + self.num_envs * (((which_time_batch + skew) + self._arange_time) % self.num_time)
+        first_idx = overall_idx[0, :]
+        return ((first_idx // self.num_envs, first_idx % self.num_envs), overall_idx)
 
     def __len__(self):
-        return self.total_size // self.batch_time
+        return self.num_envs * self.num_time // self.batch_time
+
+
+class SamplingType(enum.Enum):
+    CLASSIC = 0
+    SKEW_ZEROS = 1
+    SKEW_RANDOM = 2
 
 
 class RecurrentRolloutBuffer(RolloutBuffer):
@@ -96,11 +106,13 @@ class RecurrentRolloutBuffer(RolloutBuffer):
         gae_lambda: float = 1,
         gamma: float = 0.99,
         n_envs: int = 1,
+        sampling_type: SamplingType = SamplingType.CLASSIC,
     ):
         super(RolloutBuffer, self).__init__(buffer_size, observation_space, action_space, device=device, n_envs=n_envs)
         self.hidden_state_example = hidden_state_example
         self.gae_lambda = gae_lambda
         self.gamma = gamma
+        self.sampling_type = sampling_type
 
         batch_shape = (self.buffer_size, self.n_envs)
         self.device = device = get_device(device)
@@ -186,18 +198,45 @@ class RecurrentRolloutBuffer(RolloutBuffer):
         batch_envs: int,
     ) -> Generator[RecurrentRolloutBufferSamples, None, None]:
         assert self.full, "Rollout buffer must be full before sampling from it"
-        if batch_envs >= self.n_envs:
-            for time_start in range(0, self.buffer_size, batch_time):
-                yield self._get_samples(seq_inds=slice(time_start, time_start + batch_time), batch_inds=slice(None))
-
-        else:
-            env_indices = th.randperm(self.n_envs)
-            for env_start in range(0, self.n_envs, batch_envs):
+        if self.sampling_type == SamplingType.CLASSIC:
+            if batch_envs >= self.n_envs:
                 for time_start in range(0, self.buffer_size, batch_time):
-                    yield self._get_samples(
-                        seq_inds=slice(time_start, time_start + batch_time),
-                        batch_inds=env_indices[env_start : env_start + batch_envs],
-                    )
+                    yield self._get_samples(seq_inds=slice(time_start, time_start + batch_time), batch_inds=slice(None))
+
+            else:
+                env_indices = th.randperm(self.n_envs)
+                for env_start in range(0, self.n_envs, batch_envs):
+                    for time_start in range(0, self.buffer_size, batch_time):
+                        yield self._get_samples(
+                            seq_inds=slice(time_start, time_start + batch_time),
+                            batch_inds=env_indices[env_start : env_start + batch_envs],
+                        )
+        else:
+            if self.sampling_type == SamplingType.SKEW_ZEROS:
+                skew = th.zeros(self.n_envs, dtype=th.long, device=self.device)
+            elif self.sampling_type == SamplingType.SKEW_RANDOM:
+                skew = th.randint(0, self.buffer_size, size=(self.n_envs,), dtype=th.long, device=self.device)
+            else:
+                raise ValueError(f"unknown SkewEnum {self.sampling_type=}")
+
+            dset = TimeContiguousBatchesDataset(self.n_envs, self.buffer_size, batch_time, skew, device=self.device)
+            batch_indices = th.randperm(len(dset), dtype=th.long, device=self.device)
+
+            def _index_first_shape(idx, x):
+                return x.view(x.shape[0] * x.shape[1], *x.shape[2:])[idx]
+
+            for i in range(0, len(batch_indices), batch_envs):
+                (first_time_idx, first_env_idx), idx = dset.get_batch_and_init_times(batch_indices[i : i + batch_envs])
+                yield RecurrentRolloutBufferSamples(
+                    observations=tree_map(functools.partial(_index_first_shape, idx), self.data.observations),
+                    actions=self.data.actions.view(-1)[idx],
+                    old_values=self.data.values.view(-1)[idx],
+                    old_log_prob=self.data.log_probs.view(-1)[idx],
+                    advantages=self.advantages.view(-1)[idx],
+                    returns=self.returns.view(-1)[idx],
+                    hidden_states=tree_index(self.data.hidden_states, (first_time_idx, slice(None), first_env_idx)),
+                    episode_starts=self.data.episode_starts.view(-1)[idx],
+                )
 
     def _get_samples(  # type: ignore[override]
         self,

--- a/stable_baselines3/common/recurrent/buffers.py
+++ b/stable_baselines3/common/recurrent/buffers.py
@@ -76,8 +76,9 @@ class TimeContiguousBatchesDataset:
 
 
 class SamplingType(enum.Enum):
-    CLASSIC = 0
-    SKEW_ZEROS = 1
+    CLASSIC = 0  # for each training epoch, randomize the environment order and go sequentially through time.
+    SKEW_ZEROS = 1  # Pick random environments and time-slices. All the time-slices are aligned.
+    # Pick random environments and time-slices, which are skewed a random amount compared to the start of the buffer.
     SKEW_RANDOM = 2
 
 

--- a/stable_baselines3/ppo_recurrent/ppo_recurrent.py
+++ b/stable_baselines3/ppo_recurrent/ppo_recurrent.py
@@ -108,7 +108,7 @@ class RecurrentPPO(OnPolicyAlgorithm, Generic[RecurrentState]):
         n_steps: int = 128,
         batch_envs: int = 128,
         batch_time: Optional[int] = None,
-        sampling_type: SamplingType = SamplingType.SKEW_RANDOM,
+        sampling_type: SamplingType = SamplingType.CLASSIC,
         n_epochs: int = 10,
         gamma: float = 0.99,
         gae_lambda: float = 0.95,

--- a/stable_baselines3/ppo_recurrent/ppo_recurrent.py
+++ b/stable_baselines3/ppo_recurrent/ppo_recurrent.py
@@ -12,7 +12,10 @@ from stable_baselines3.common.callbacks import BaseCallback
 from stable_baselines3.common.on_policy_algorithm import OnPolicyAlgorithm
 from stable_baselines3.common.policies import BasePolicy
 from stable_baselines3.common.pytree_dataclass import tree_index, tree_map
-from stable_baselines3.common.recurrent.buffers import RecurrentRolloutBuffer
+from stable_baselines3.common.recurrent.buffers import (
+    RecurrentRolloutBuffer,
+    SamplingType,
+)
 from stable_baselines3.common.recurrent.policies import BaseRecurrentActorCriticPolicy
 from stable_baselines3.common.recurrent.torch_layers import RecurrentState
 from stable_baselines3.common.recurrent.type_aliases import RecurrentRolloutBufferData
@@ -105,6 +108,7 @@ class RecurrentPPO(OnPolicyAlgorithm, Generic[RecurrentState]):
         n_steps: int = 128,
         batch_envs: int = 128,
         batch_time: Optional[int] = None,
+        sampling_type: SamplingType = SamplingType.SKEW_RANDOM,
         n_epochs: int = 10,
         gamma: float = 0.99,
         gae_lambda: float = 0.95,
@@ -153,6 +157,7 @@ class RecurrentPPO(OnPolicyAlgorithm, Generic[RecurrentState]):
         )
         if batch_time is None:
             batch_time = self.n_steps
+        self.sampling_type = sampling_type
         # Sanity check, otherwise it will lead to noisy gradient and NaN
         # because of the advantage normalization
         if normalize_advantage:
@@ -259,6 +264,7 @@ class RecurrentPPO(OnPolicyAlgorithm, Generic[RecurrentState]):
             gamma=self.gamma,
             gae_lambda=self.gae_lambda,
             n_envs=self.n_envs,
+            sampling_type=self.sampling_type,
         )
         self._last_lstm_states = tree_map(lambda x: th.zeros_like(x, memory_format=th.contiguous_format), hidden_state_example)
 

--- a/tests/test_buffers.py
+++ b/tests/test_buffers.py
@@ -15,6 +15,7 @@ from stable_baselines3.common.env_util import make_vec_env
 from stable_baselines3.common.pytree_dataclass import tree_flatten
 from stable_baselines3.common.recurrent.buffers import (
     RecurrentRolloutBuffer,
+    SamplingType,
     TimeContiguousBatchesDataset,
 )
 from stable_baselines3.common.recurrent.type_aliases import RecurrentRolloutBufferData
@@ -128,11 +129,20 @@ HIDDEN_STATES_EXAMPLE = {"a": {"b": th.zeros(2, 4)}}
 
 
 @pytest.mark.parametrize(
-    "replay_buffer_cls", [DictReplayBuffer, DictRolloutBuffer, ReplayBuffer, RolloutBuffer, RecurrentRolloutBuffer]
+    "replay_buffer_cls, sampling_type",
+    [
+        (DictReplayBuffer, None),
+        (DictRolloutBuffer, None),
+        (ReplayBuffer, None),
+        (RolloutBuffer, None),
+        (RecurrentRolloutBuffer, SamplingType.CLASSIC),
+        (RecurrentRolloutBuffer, SamplingType.SKEW_ZEROS),
+        (RecurrentRolloutBuffer, SamplingType.SKEW_RANDOM),
+    ],
 )
 @pytest.mark.parametrize("n_envs", [1, 4])
 @pytest.mark.parametrize("device", ["cpu", "cuda", "auto"])
-def test_device_buffer(replay_buffer_cls, n_envs, device):
+def test_device_buffer(replay_buffer_cls, sampling_type, n_envs, device):
     if device == "cuda" and not th.cuda.is_available():
         pytest.skip("CUDA not available")
 
@@ -155,6 +165,7 @@ def test_device_buffer(replay_buffer_cls, n_envs, device):
             hidden_state_example=N_ENVS_HIDDEN_STATES,
             device=device,
             n_envs=n_envs,
+            sampling_type=sampling_type,
         )
     else:
         buffer = replay_buffer_cls(EP_LENGTH, env.observation_space, env.action_space, device=device, n_envs=n_envs)
@@ -214,7 +225,9 @@ def test_time_contiguous_batches_dataset(num_envs, num_time, batch_time, skew_ze
     else:
         skew = th.arange(1, num_envs + 1, dtype=th.long) % num_time
 
-    d = TimeContiguousBatchesDataset(num_envs=num_envs, num_time=num_time, batch_time=batch_time, skew=skew)
+    d = TimeContiguousBatchesDataset(
+        num_envs=num_envs, num_time=num_time, batch_time=batch_time, skew=skew, device=th.device("cpu")
+    )
 
     assert len(d) == num_time_batches * num_envs
 
@@ -235,6 +248,8 @@ def test_time_contiguous_batches_dataset(num_envs, num_time, batch_time, skew_ze
 
     for batch in th.split(th.arange(len(d)), min(len(d), 4)):
         if len(batch) > 0:
-            individual = th.vstack([d[int(b.item())] for b in batch])
-            collective = d.__getitems__(batch)
+            individual = th.vstack([d[int(b.item())] for b in batch]).T
+            (first_time, first_envs), collective = d.get_batch_and_init_times(batch)
             assert th.equal(individual, collective)
+
+            assert th.equal(first_time * num_envs + first_envs, collective[0])

--- a/tests/test_lstm.py
+++ b/tests/test_lstm.py
@@ -310,7 +310,7 @@ def test_ppo_lstm_performance(policy: str | type[BaseRecurrentActorCriticPolicy]
         batch_envs=N_ENVS,
         batch_time=BATCH_TIME,
         sampling_type=sampling_type,
-        seed=5,
+        seed=6,
         n_epochs=10,
         max_grad_norm=1,
         gae_lambda=0.98,

--- a/tests/test_lstm.py
+++ b/tests/test_lstm.py
@@ -16,6 +16,7 @@ from stable_baselines3.common.env_util import make_vec_env
 from stable_baselines3.common.envs import FakeImageEnv
 from stable_baselines3.common.evaluation import evaluate_policy
 from stable_baselines3.common.pytree_dataclass import SB3_NAMESPACE
+from stable_baselines3.common.recurrent.buffers import SamplingType
 from stable_baselines3.common.recurrent.policies import (
     BaseRecurrentActorCriticPolicy,
     RecurrentFeaturesExtractorActorCriticPolicy,
@@ -273,7 +274,8 @@ def test_dict_obs_recurrent_extractor():
 
 @pytest.mark.expensive
 @pytest.mark.parametrize("policy", ["MlpLstmPolicy", "GRUFeatureExtractorPolicy"])
-def test_ppo_lstm_performance(policy: str | type[BaseRecurrentActorCriticPolicy]):
+@pytest.mark.parametrize("sampling_type", [SamplingType.CLASSIC, SamplingType.SKEW_RANDOM, SamplingType.SKEW_ZEROS])
+def test_ppo_lstm_performance(policy: str | type[BaseRecurrentActorCriticPolicy], sampling_type: SamplingType):
     # env = make_vec_env("CartPole-v1", n_envs=16)
     def make_env():
         env = CartPoleNoVelEnv()
@@ -307,6 +309,7 @@ def test_ppo_lstm_performance(policy: str | type[BaseRecurrentActorCriticPolicy]
         verbose=1,
         batch_envs=N_ENVS,
         batch_time=BATCH_TIME,
+        sampling_type=sampling_type,
         seed=1,
         n_epochs=10,
         max_grad_norm=1,

--- a/tests/test_lstm.py
+++ b/tests/test_lstm.py
@@ -310,7 +310,7 @@ def test_ppo_lstm_performance(policy: str | type[BaseRecurrentActorCriticPolicy]
         batch_envs=N_ENVS,
         batch_time=BATCH_TIME,
         sampling_type=sampling_type,
-        seed=1,
+        seed=5,
         n_epochs=10,
         max_grad_norm=1,
         gae_lambda=0.98,


### PR DESCRIPTION
Let the Recurrent batches scramble the training batches to feed to the RNN in many different ways: at each step pick random environments and contiguous time-slices, and feed them to the model.

In actuality this didn't improve learning performance at all and decreased FPS, so I don't want to spend much more time in it. Still, now the `SamplingType` is in the config of old experiments, and it may be useful...
